### PR TITLE
Add interactive tooltips and clarify tables for TB pages

### DIFF
--- a/pages/2_diagnostic_tests_for_latent_tb_infection_(ltbi)__e__interferon_y_release_assays_(igras).html
+++ b/pages/2_diagnostic_tests_for_latent_tb_infection_(ltbi)__e__interferon_y_release_assays_(igras).html
@@ -58,6 +58,7 @@
     </p>
     <h4 id="table1" class="custom-table-title">Table 1. Interpretation Criteria for the QuantiFERON-TB Gold Plus Test (QFT-Plus)</h4>
     <div class="uk-overflow-auto">
+         <p class="chapter-title">Possible Test Results</p>
         <div class="uk-tabs-container">
             <ul class="tabs">
                 <li><button class="tab active-tab" onclick="switchTab(0, event)">Positive</button></li>
@@ -151,86 +152,108 @@
     <p>
         <b>Source</b>: Based on manufacturer recommendations for QuantiFERON-TB Gold Plus [Package insert]. <br>Available
         at:
-        <a href="https://www.qiagen.com/us/resources/download.aspx?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en" class="res-width">
-            https://www.qiagen.com/us/resources/download.aspx?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en</a>
+        <a href="https://www.qiagen.com/us/resources/resource?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en" class="res-width">
+            https://www.qiagen.com/us/resources/resource?id=ac068fc7-a994-4443-ac7c-dda43ce2bc5e&lang=en</a>
     </p>
     
     <h4 id="table2" class="custom-table-title">Table 2. Interpretation Criteria for the T-SPOT.TB Test (T-Spot)</h4>
     <div class="uk-overflow-auto" id="table2">
         <div class="uk-tabs-container">
             <ul class="tabs">
-                <li><button class="tab-button active-option" onclick="switchTab(0, event)">Positive</button></li>
-                <li><button class="tab-button" onclick="switchTab(1, event)">Borderline</button></li>
-                <li><button class="tab-button" onclick="switchTab(2, event)">Negative</button></li>
-                <li><button class="tab-button" onclick="switchTab(3, event)">Invalid</button></li>
+                <li><button class="tab active-tab" onclick="switchTab(0, event)">Positive¹</button></li>
+                <li><button class="tab" onclick="switchTab(1, event)">Borderline²</button></li>
+                <li><button class="tab" onclick="switchTab(2, event)">Negative³</button></li>
+                <li><button class="tab" onclick="switchTab(3, event)">Invalid⁴</button></li>
             </ul>
         </div>
 
         <table id="option-content0" class="uk-table tab-content option-content active-option">
             <tbody>
                 <tr>
-                    <th colspan="1">Nil*</th>
+                    <th colspan="1">Nil
+                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from incubation of PBMCs in culture media without antigens." data-tooltip-position="tooltip-right">i</span></th>
                     <td colspan="1">&le; 10 spots</td>
                 </tr>
                 <tr>
-                    <th colspan="1">TB Response†</th>
+                    <th colspan="1">TB Response
+                        <span class="info-icon" data-tooltip="NOTE: The greater number of spots resulting from stimulation of peripheral blood mononuclear cells (PBMCs) with two separate cocktails of peptides representing early secretory antigenic target-6 (ESAT-6) or culture filtrate protein-10 (CFP-10) minus Nil.">i</span></th>
+                    </th>
                     <td colspan="1">&ge; 8 spots</td>
                 </tr>
                 <tr>
-                    <th colspan="1">Mitogen&sect;</th>
+                    <th colspan="1">Mitogen
+                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from stimulation of PBMCs with mitogen without adjustment for the number of spots resulting from incubation of PBMCs without antigens."data-tooltip-position="tooltip-right">i</span>
+                    </th>
                     <td colspan="1">Any</td>
                 </tr>
             </tbody>
         </table>
-
         <table id="option-content1" class="uk-table tab-content option-content">
             <tbody>
                 <tr>
-                    <th colspan="1">Nil*</th>
+                    <th colspan="1">Nil
+                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from incubation of PBMCs in culture media without antigens.">i</span>
+                    </th>
                     <td colspan="1">&lt; 10 spots</td>
                 </tr>
                 <tr>
-                    <th colspan="1">TB Response†</th>
+                    <th colspan="1">TB Response
+                        <span class="info-icon" data-tooltip="NOTE: The greater number of spots resulting from stimulation of peripheral blood mononuclear cells (PBMCs) with two separate cocktails of peptides representing early secretory antigenic target-6 (ESAT-6) or culture filtrate protein-10 (CFP-10) minus Nil.">i</span>
+                    </th>
                     <td colspan="1">5, 6, or 7 spots</td>
                 </tr>
                 <tr>
-                    <th colspan="1">Mitogen&sect;</th>
+                    <th colspan="1">Mitogen
+                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from stimulation of PBMCs with mitogen without adjustment for the number of spots resulting from incubation of PBMCs without antigens.">i</span>
+                    </th>
                     <td colspan="1">Any</td>
                 </tr>
             </tbody>
         </table>
 
-        <table id="option-content2" class="uk-table tab-content option-content">
+              <table id="option-content2" class="uk-table tab-content option-content">
             <tbody>
                 <tr>
-                    <th colspan="1">Nil*</th>
+                    <th colspan="1">Nil
+                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from incubation of PBMCs in culture media without antigens.">i</span>
+                    </th>
                     <td colspan="1">&le; 10 spots</td>
                 </tr>
                 <tr>
-                    <th colspan="1">TB Response†</th>
+                    <th colspan="1">TB Response
+                        <span class="info-icon" data-tooltip="NOTE: The greater number of spots resulting from stimulation of peripheral blood mononuclear cells (PBMCs) with two separate cocktails of peptides representing early secretory antigenic target-6 (ESAT-6) or culture filtrate protein-10 (CFP-10) minus Nil.">i</span>
+                    </th>
                     <td colspan="1">> 20 spots</td>
                 </tr>
                 <tr>
-                    <th colspan="1">Mitogen&sect;</th>
+                    <th colspan="1">Mitogen
+                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from stimulation of PBMCs with mitogen without adjustment for the number of spots resulting from incubation of PBMCs without antigens.">i</span>
+                    </th>
                     <td colspan="1">> 20 spots</td>
                 </tr>
             </tbody>
         </table>
 
-        <table id="option-content3" class="uk-table tab-content option-content">
+ <table id="option-content3" class="uk-table tab-content option-content">
             <tbody>
                 <tr>
-                    <th colspan="1">Nil*</th>
+                    <th colspan="1">Nil
+                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from incubation of PBMCs in culture media without antigens.">i</span>
+                    </th>
                     <td colspan="1">&le; 10 spots</td>
                     <td colspan="1">&le; 10 spots</td>
                 </tr>
                 <tr>
-                    <th colspan="1">TB Response†</th>
+                    <th colspan="1">TB Response
+                        <span class="info-icon" data-tooltip="NOTE: The greater number of spots resulting from stimulation of peripheral blood mononuclear cells (PBMCs) with two separate cocktails of peptides representing early secretory antigenic target-6 (ESAT-6) or culture filtrate protein-10 (CFP-10) minus Nil.">i</span>
+                    </th>
                     <td colspan="1">Any</td>
                     <td colspan="1">< 5 spots</td>
                 </tr>
                 <tr>
-                    <th class="uk-table-small" colspan="1">Mitogen&sect;</th>
+                    <th class="uk-table-small" colspan="1">Mitogen
+                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from stimulation of PBMCs with mitogen without adjustment for the number of spots resulting from incubation of PBMCs without antigens.">i</span>
+                    </th>
                     <td colspan="1">Any</td>
                     <td colspan="1">< 20 spots</td>
                 </tr>
@@ -238,28 +261,13 @@
         </table>
 
     </div>
-    <p>
-        <b>Source</b>: Based on Oxford Immunotec T-Spot.TB package insert. <br>
-        Available at: <a
-            href="https://www.tspot.com/wp-content/uploads/2021/04/TB-PI-US-0001-V9.pdf" class="res-width">
-        https://www.tspot.com/wp-content/uploads/2021/04/TB-PI-US-0001-V9.pdf
-    </a>
-    </p>
-
-    <p>* The number of spots resulting from incubation of PBMCs in culture media without antigens. <br>
-        † The greater number of spots resulting from stimulation of peripheral
-        blood mononuclear cells (PBMCs) with two separate cocktails of peptides
-        representing early secretory antigenic target-6 (ESAT-6) or culture filtrate
-        protein-10 (CFP-10) minus Nil. <br>
-        § The number of spots resulting from stimulation of PBMCs with mitogen
-        without adjustment for the number of spots resulting from incubation of
-        PBMCs without antigens. <br>
-        ¶ Interpretation indicating that Mycobacterium tuberculosis infection is
-        likely. <br>
-        ** Interpretation indicating an uncertain likelihood of M. tuberculosis infection. In the case of Invalid
-        results, these should be reported as “Invalid”
-        and it is recommended to collect another sample and retest the individual. <br>
-        †† Interpretation indicating that M. tuberculosis infection is not likely. </p>
+       <p>Source: Based on Oxford Immunotec T-Spot.TB package insert. <br>
+    Available at: <a href="http://www.oxfordimmunotec.com/international/wp-content/uploads/sites/3/Final-File-PI-TB-US-V6.pdf " class="res-width">
+    http://www.oxfordimmunotec.com/international/wp-content/uploads/sites/3/Final-File-PI-TB-US-V6.pdf
+    </a></p>
+    <p>1. Interpretation indicating that Mycobacterium tuberculosis infection is likely. <br>
+    2. Interpretation indicating an uncertain likelihood of M. tuberculosis infection. In the case of Invalid results, these should be reported as “Invalid” and it is recommended to collect another sample and retest the individual. <br>
+    3. Interpretation indicating that M. tuberculosis infection is not likely.</p>
 
 </div>
 </body>
@@ -267,4 +275,57 @@
 <script src="../assets/uikit.js" type="text/javascript"></script>
 <script src="../assets/uikit-icons.js" type="text/javascript"></script>
 <script src="../assets/main.js" type="text/javascript"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+    const tooltips = document.querySelectorAll(".info-icon");
+
+    document.addEventListener("click", function (event) {
+    if (!event.target.closest(".info-icon")) {
+        document
+        .querySelectorAll(".info-icon.active")
+        .forEach((activeIcon) => {
+            activeIcon.classList.remove("active");
+        });
+    }
+    });
+
+    tooltips.forEach(function (icon) {
+    let tooltip = icon.querySelector(".tooltip");
+    if (!tooltip) {
+        tooltip = document.createElement("div");
+        tooltip.className = "tooltip";
+        tooltip.textContent =
+        icon.getAttribute("data-tooltip") || "Additional information";
+
+        // Get positioning class from data attribute
+        const positionClass =
+        icon.getAttribute("data-tooltip-position") || "tooltip-center";
+        tooltip.classList.add(positionClass);
+
+        icon.appendChild(tooltip);
+    }
+
+    let isTooltipVisible = false;
+
+    icon.addEventListener("click", function (event) {
+        event.stopPropagation();
+
+        document
+        .querySelectorAll(".info-icon.active")
+        .forEach((activeIcon) => {
+            if (activeIcon !== icon) {
+            activeIcon.classList.remove("active");
+            const otherTooltip = activeIcon.querySelector(".tooltip");
+            if (otherTooltip) otherTooltip.style.display = "none";
+            }
+        });
+
+        isTooltipVisible = !this.classList.contains("active");
+        this.classList.toggle("active");
+        tooltip.style.display = isTooltipVisible ? "block" : "none";
+    });
+    });
+});
+
+</script>
 </html>

--- a/pages/2_diagnostic_tests_for_latent_tb_infection_(ltbi)__f__targeted_testing_and_diagnostic_tests_for_ltbi.html
+++ b/pages/2_diagnostic_tests_for_latent_tb_infection_(ltbi)__f__targeted_testing_and_diagnostic_tests_for_ltbi.html
@@ -167,7 +167,8 @@
             </tr>
             <tr>
                 <td>Persons who inject drugs</td>
-                <td>Persons with certain medical conditions*</td>
+                <td>Persons with certain medical conditions <span class="info-icon" data-tooltip="NOTE: Diabetes mellitus, silicosis, prolonged therapy with corticosteroids, immunosuppressive therapy particularly TNF-α blockers, leukemia, Hodgkin’s disease, head and neck cancers, severe kidney disease, certain intestinal conditions, malnutrition."
+                    data-tooltip-position="tooltip-left">i</span></td>
             </tr>
             <tr>
                 <td colspan="2">*Diabetes mellitus, silicosis, prolonged therapy with corticosteroids, immunosuppressive
@@ -281,4 +282,57 @@
 <script src="../assets/uikit.js" type="text/javascript"></script>
 <script src="../assets/uikit-icons.js" type="text/javascript"></script>
 <script src="../assets/main.js" type="text/javascript"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+    const tooltips = document.querySelectorAll(".info-icon");
+
+    document.addEventListener("click", function (event) {
+    if (!event.target.closest(".info-icon")) {
+        document
+        .querySelectorAll(".info-icon.active")
+        .forEach((activeIcon) => {
+            activeIcon.classList.remove("active");
+        });
+    }
+    });
+
+    tooltips.forEach(function (icon) {
+    let tooltip = icon.querySelector(".tooltip");
+    if (!tooltip) {
+        tooltip = document.createElement("div");
+        tooltip.className = "tooltip";
+        tooltip.textContent =
+        icon.getAttribute("data-tooltip") || "Additional information";
+
+        // Get positioning class from data attribute
+        const positionClass =
+        icon.getAttribute("data-tooltip-position") || "tooltip-center";
+        tooltip.classList.add(positionClass);
+
+        icon.appendChild(tooltip);
+    }
+
+    let isTooltipVisible = false;
+
+    icon.addEventListener("click", function (event) {
+        event.stopPropagation();
+
+        document
+        .querySelectorAll(".info-icon.active")
+        .forEach((activeIcon) => {
+            if (activeIcon !== icon) {
+            activeIcon.classList.remove("active");
+            const otherTooltip = activeIcon.querySelector(".tooltip");
+            if (otherTooltip) otherTooltip.style.display = "none";
+            }
+        });
+
+        isTooltipVisible = !this.classList.contains("active");
+        this.classList.toggle("active");
+        tooltip.style.display = isTooltipVisible ? "block" : "none";
+    });
+    });
+});
+
+</script>
 </html>

--- a/pages/3_treatment_of_latent_tb_infection_(ltbi)__a__treatment_regimens.html
+++ b/pages/3_treatment_of_latent_tb_infection_(ltbi)__a__treatment_regimens.html
@@ -128,8 +128,8 @@
     <div id="table_4_recommendations_for_regimens_to_treat_latent_tuberculosis_infection" class="uk-overflow-auto">
         <div class="uk-tabs-container">
             <ul class="tabs">
-                <li><button class="tab active-tab" onclick="switchTab(0, event)">Preferred</button></li>
-                <li><button class="tab" onclick="switchTab(1, event)">Alternative</button></li>
+                <li><button class="tab active-tab" onclick="switchTab(0, event)">Preferred¹</button></li>
+                <li><button class="tab" onclick="switchTab(1, event)">Alternative²</button></li>
             </ul>
         </div>
 
@@ -137,9 +137,15 @@
             <tbody>
                 <tr>
                     <th>Regimes</th>
-                    <td>3 months isoniazid plus rifapentine given once weekly</td>
-                    <td>4 months rifampin given daily</td>
-                    <td>3 months isoniazid plus rifampin given daily</td>
+                    <td>3 months isoniazid plus rifapentine</td>
+                    <td>4 months rifampin</td>
+                    <td>3 months isoniazid plus rifampin</td>
+                </tr>
+                <tr>
+                    <th>Frequency</th>
+                    <td>Once weekly</td>
+                    <td>Daily</td>
+                    <td>Daily</td>
                 </tr>
                 <tr>
                     <th>Recommendation (Strong or Conditional)</th>
@@ -150,8 +156,8 @@
                 <tr>
                     <th>Evidence (High, Moderate, Low, or Very Low)</th>
                     <td>Moderate</td>
-                    <td>Moderate (HIV negative) † </td>
-                    <td>Very low (HIV negative) † </td>
+                    <td>Moderate (HIV negative) <span class="info-icon" data-tooltip="NOTE: No evidence reported in HIV-positive persons." data-tooltip-position="tooltip-left">i</span> </td>
+                    <td>Very low (HIV negative) / Low (HIV positive) <span class="info-icon" data-tooltip="NOTE: No evidence reported in HIV-positive persons." data-tooltip-position="tooltip-left">i</span> </td>
                 </tr>
             </tbody>
         </table>
@@ -160,13 +166,19 @@
             <tbody>
                 <tr>
                     <th>Regimes</th>
-                    <td>6 months isoniazid given daily</td>
-                    <td>9 months isoniazid given daily</td>
-                    <td>3 months isoniazid plus rifampin given daily</td>
+                    <td>6 months isoniazid</td>
+                    <td>6 months isoniazid</td>
+                    <td>9 months isoniazid</td>
+                </tr>
+                <tr>
+                    <th>Frequency</th>
+                    <td>Daily</td>
+                    <td>Daily</td>
+                    <td>Daily</td>
                 </tr>
                 <tr>
                     <th>Recommendation (Strong or Conditional)</th>
-                    <td>Strong &sect;</td>
+                    <td>Strong <span class="info-icon" data-tooltip="NOTE: Strong recommendation for those persons unable to take a preferred regimen (e.g., due to drug intolerability or drug-drug interactions)." data-tooltip-position="tooltip-center">i</span></td>
                     <td>Conditional</td>
                     <td>Conditional</td>
                 </tr>
@@ -178,19 +190,11 @@
                 </tr>
             </tbody>
         </table>
-
-
     </div>
-
-    <p>Abbreviation: HIV = human immunodeficiency virus <br>
-        <i>* Preferred: excellent tolerability and efficacy, shorter treatment duration,
-            higher completion rates than longer regimens, and therefore higher
-            effectiveness. Alternative: excellent efficacy but concerns regarding longer
-            treatment duration, lower completion rates, and therefore lower effectiveness.
-        </i> <br>† No evidence reported in HIV-positive persons. <br>
-        § Strong recommendation for those persons unable to take a preferred
-        regimen (e.g., due to drug intolerability or drug-drug interactions).
-    </p>
+    
+    <p>Abbreviation: HIV = human immunodeficiency virus</p>
+    <p>1. Preferred: excellent tolerability and efficacy, shorter treatment duration, higher completion rates than longer regimens, and therefore higher effectiveness. <br>
+        2. Alternative: excellent efficacy but concerns regarding longer treatment duration, lower completion rates, and therefore lower effectiveness. </p>
 
     <h4 id="table5" class="custom-table-title">Table 5. Dosages for Recommended LTBI Treatment Regimens</h4>
 
@@ -198,14 +202,14 @@
 
         <div class="uk-tabs-container">
             <ul class="tabs">
-                <li><button class="tab active-tab" onclick="switchTab(0, event)">Isoniazid and Rifapentine</button></li>
-                <li><button class="tab" onclick="switchTab(1, event)">Rifampin</button></li>
-                <li><button class="tab" onclick="switchTab(2, event)">Isoniazid and Rifampin</button></li>
+                <li><button class="tab active-tab" onclick="switchTab(0, event)">Isoniazid¹ and Rifapentine²</button></li>
+                <li><button class="tab" onclick="switchTab(1, event)">Rifampin³</button></li>
+                <li><button class="tab" onclick="switchTab(2, event)">Isoniazid¹ and Rifampin³</button></li>
                 <li><button class="tab" onclick="switchTab(3, event)">Isoniazid</button></li>
             </ul>
         </div>
 
-        <table id="tab-content2" class="uk-table uk-table-small tab-content active-tab">
+        <table id="tab-content0" class="uk-table uk-table-small tab-content active-tab">
             <tbody>
                 <tr>
                     <th>Duration</th>
@@ -214,7 +218,7 @@
                 <tr>
                     <th>Dosage And Age Group</th>
                     <td>
-                        <strong class="highlight">Adults and children aged ≥ 12 yrs</strong><br>
+                        <strong class="highlight">Adults and children aged > 12 yrs</strong><br>
                         <strong>Isoniazid:</strong><br>
                         15 mg/kg rounded up to the nearest 50 or 100 mg; 900 mg maximum<br>
                         <strong>Rifapentine:</strong><br>
@@ -225,8 +229,8 @@
                         > 50.0 kg, 900 mg maximum <br>
                         <br>
                         <strong class="highlight">Children aged 2 - 11 yrs</strong><br>
-                        <strong>Isoniazid*</strong>: <br> 25 mg/kg; 900 mg maximum<br>
-                        <strong>Rifapentine†</strong>: <br>
+                        <strong class="with-info-icon">Isoniazid <span class="info-icon" data-tooltip="NOTE: Isoniazid is formulated as 100-mg and 300-mg tablets.">i</span></strong>: <br> 25 mg/kg; 900 mg maximum<br>
+                        <strong class="with-info-icon">Rifapentine <span class="info-icon" data-tooltip="NOTE: Rifapentine is formulated as 150-mg tablets in blister packs that should be kept sealed until use.">i</span></strong>: <br>
                         see above <br>
                     </td>
                 </tr>
@@ -241,7 +245,7 @@
             </tbody>
         </table>
 
-        <table id="tab-content3" class="uk-table uk-table-small tab-content">
+        <table id="tab-content1" class="uk-table uk-table-small tab-content">
             <tbody>
                 <tr>
                     <th>Duration</th>
@@ -251,11 +255,11 @@
                     <th>Dosage And Age Group</th>
                     <td>
                         <strong>Adults</strong>: 10 mg/kg<br>
-                        <strong>Children</strong>: 15 - 20 mg/kg**<br>
+                        <strong>Children</strong>: 15 - 20 mg/kg <span class="info-icon" data-tooltip="NOTE: The American Academy of Pediatrics acknowledges that some experts use rifampin at 20 - 30 mg/kg for the daily regimen when prescribing for infants and toddlers. (Source: American Academy of Pediatrics. Tuberculosis. In: Kimberlin DW, Brady MT, Jackson MA, Long SS, eds. Red Book: 2018 Report of the Committee on Infectious Diseases. 31st ed. Itasca, IL: American Academy of Pediatrics; 2018:829-53)." data-tooltip-position="tooltip-left">i</span><br>
                         <strong>Maximum dose</strong>: 600 mg<br>
                     </td>
                 </tr>
-                <tr>
+                <tr> 
                     <th>Frequency</th>
                     <td>Daily</td>
                 </tr>
@@ -266,7 +270,7 @@
             </tbody>
         </table>
 
-        <table id="tab-content4" class="uk-table uk-table-small tab-content">
+        <table id="tab-content2" class="uk-table uk-table-small tab-content">
             <tbody>
                 <tr>
                     <th>Duration</th>
@@ -276,11 +280,11 @@
                     <th>Dosage And Age Group</th>
                     <td>
                         <strong class="highlight">Adults </strong> <br>
-                        <strong>Isoniazid*</strong>: <br> 5 mg/kg; 300 mg maximum <br>
-                        <strong>Rifampin¶</strong>: <br> 10 mg/kg; 600 mg maximum <br><br>
+                        <strong>Isoniazid <span class="info-icon" data-tooltip="NOTE: Isoniazid is formulated as 100-mg and 300-mg tablets." data-tooltip-position="tooltip-left">i</span></strong>: <br> 5 mg/kg; 300 mg maximum <br>
+                        <strong>Rifampin <span class="info-icon" data-tooltip="NOTE: Rifampin (rifampicin) is formulated as 150-mg and 300-mg capsules." data-tooltip-position="tooltip-left">i</span></strong>: <br> 10 mg/kg; 600 mg maximum <br><br>
                         <strong class="highlight">Children</strong>: <br>
-                        <strong>Isoniazid*</strong>: <br> 10 - 20 mg/kg†† ; 300 mg maximum <br>
-                        <strong>Rifampin¶</strong>: <br> 15 - 20 mg/kg; 600 mg maximum <br>
+                        <strong>Isoniazid <span class="info-icon" data-tooltip="NOTE: Isoniazid is formulated as 100-mg and 300-mg tablets." data-tooltip-position="tooltip-left">i</span></strong>: <br> 10 - 20 mg/kg <span class="info-icon" data-tooltip="NOTE: The American Academy of Pediatrics recommends an isoniazid dosage of 10 - 15 mg/kg for the daily regimen. Adapted from MMWR Recomm Rep 2020; 69(1):1-11.">i</span> ; 300 mg maximum <br>
+                        <strong>Rifampin <span class="info-icon" data-tooltip="NOTE: Rifampin (rifampicin) is formulated as 150-mg and 300-mg capsules." data-tooltip-position="tooltip-left">i</span></strong>: <br> 15 - 20 mg/kg; 600 mg maximum <br>
                     </td>
                 </tr>
                 <tr>
@@ -294,7 +298,7 @@
             </tbody>
         </table>
 
-        <table id="tab-content5" class="uk-table uk-table-small tab-content">
+        <table id="tab-content3" class="uk-table uk-table-small tab-content">
             <tbody>
                 <tr>
                     <th>Duration</th>
@@ -305,12 +309,12 @@
                     <th>Dosage And Age Group</th>
                     <td>
                         <strong>Adults</strong>: <br> 5 mg/kg <br>
-                        <strong>Children</strong>: <br> 10 - 20 mg/kg†† <br>
+                        <strong>Children</strong>: <br> 10 - 20 mg/kg <span class="info-icon" data-tooltip="NOTE: The American Academy of Pediatrics recommends an isoniazid dosage of 10 - 15 mg/kg for the daily regimen.  Adapted from MMWR Recomm Rep 2020; 69(1):1-11.">i</span> <br>
                         <strong>Maximum dose</strong>: <br> 300 mg <br>
                     </td>
                     <td>
                         <strong>Adults</strong>: <br> 5 mg/kg <br>
-                        <strong>Children</strong>: <br> 10 - 20 mg/kg†† <br>
+                        <strong>Children</strong>: <br> 10 - 20 mg/kg <span class="info-icon" data-tooltip="NOTE: The American Academy of Pediatrics recommends an isoniazid dosage of 10 - 15 mg/kg for the daily regimen.  Adapted from MMWR Recomm Rep 2020; 69(1):1-11.">i</span> <br>
                         <strong>Maximum dose</strong>: <br> 300 mg <br>
                     </td>
                 </tr>
@@ -328,8 +332,10 @@
         </table>
     </div>
 
-     <p>
-        * Isoniazid is formulated as 100-mg and 300-mg tablets. † Rifapentine is formulated as 150-mg tablets in blister packs that should be kept sealed until use. Rifapentine should not be used for children &lt2 years of age due to lack of pharmacokinetic data.¶ Rifampin (rifampicin) is formulated as 150-mg and 300-mg capsules.   ** The American Academy of Pediatrics acknowledges that some experts use rifampin at 20 - 30 mg/kg for the daily regimen when prescribing for infants and toddlers. (Source: American Academy of Pediatrics. Tuberculosis. In: Kimberlin DW, Brady MT, Jackson MA, Long SS, eds. Red Book: 2018 Report of the Committee on Infectious Diseases. 31st ed. Itasca, IL: American Academy of Pediatrics; 2018:829-53). †† The American Academy of Pediatrics recommends an isoniazid dosage of 10 - 15 mg/kg for the daily regimen. Adapted from MMWR Recomm Rep 2020; 69(1):1-11.
+    <p>
+        1. Isoniazid is formulated as 100-mg and 300-mg tablets.<br>
+        2. Rifapentine is formulated as 150-mg tablets in blister packs that should be kept sealed until use. Rifapentine should not be used for children <2 years of age due to lack of pharmacokinetic data.<br>
+        3. Rifampin (rifampicin) is formulated as 150-mg and 300-mg capsules.
     </p>
 
     <h4 id="table6" class="custom-table-title">Table 6. LTBI Treatment Drug Adverse Reactions</h4>
@@ -342,7 +348,7 @@
             </ul>
         </div>
 
-        <table id="tab-content6" class="uk-table uk-table-small tab-content active-tab">
+         <table id="tab-content0" class="uk-table uk-table-small tab-content active-tab">
             <tbody>
                 <tr>
                     <th>Adverse Reactions</th>
@@ -355,7 +361,25 @@
                         Monitoring
                     </th>
                     <td>
-                        Order baseline hepatic chemistry blood tests (at least AST or ALT) for patients with specific conditions: Living with HIV, liver disorders, postpartum period (&lt3 months after delivery), regular alcohol use, injection drug use, or use of medications with known possible interactions. [Some clinicians prefer to obtain baseline tests on all adults]. Repeat measurements if: * baseline results are abnormal * client is at high-risk for adverse reactions * client has symptoms of adverse reactions
+                       Order baseline hepatic chemistry blood tests (at least AST or ALT) for patients with specific conditions: Living with HIV, liver disorders, postpartum period (&lt3 months after delivery), regular alcohol use, injection drug use, or use of medications with known possible interactions. [Some clinicians prefer to obtain baseline tests on all adults]. Repeat measurements if: <span class="info-icon" data-tooltip="NOTE: 
+
+Hypersensitivity reaction to rifamycins (rifampin, rifabutin, or rifapentine): reactions may include a flu-like syndrome (e.g. fever, chills, headaches, dizziness, musculoskeletal pain), thrombocytopenia, shortness of breath or other signs and symptoms including wheezing, acute bronchospasm, urticaria, petechiae, purpura, pruritus, conjunctivitis, angioedema, hypotension or shock.
+If moderate to severe reaction (e.g. thrombocytopenia, hypotension), hospitalization or life-threatening event: Discontinue treatment.
+If mild reaction (e.g. rash, dizziness, fever): Continue to monitor patient closely with a low threshold for discontinuing treatment.
+A flu-like syndrome appears to be the most common side effect profile leading to discontinuation of the 3HP regimen.
+Rifabutin can rarely cause uveitis." data-tooltip-position="tooltip-center">i</span> baseline results are abnormal <span class="info-icon" data-tooltip="NOTE:
+
+Hypersensitivity reaction to rifamycins (rifampin, rifabutin, or rifapentine): reactions may include a flu-like syndrome (e.g. fever, chills, headaches, dizziness, musculoskeletal pain), thrombocytopenia, shortness of breath or other signs and symptoms including wheezing, acute bronchospasm, urticaria, petechiae, purpura, pruritus, conjunctivitis, angioedema, hypotension or shock.
+If moderate to severe reaction (e.g. thrombocytopenia, hypotension), hospitalization or life-threatening event: Discontinue treatment.
+If mild reaction (e.g. rash, dizziness, fever): Continue to monitor patient closely with a low threshold for discontinuing treatment.
+A flu-like syndrome appears to be the most common side effect profile leading to discontinuation of the 3HP regimen.
+Rifabutin can rarely cause uveitis." data-tooltip-position="tooltip-center">i</span> client is at high-risk for adverse reactions <span class="info-icon" data-tooltip="NOTE:
+
+Hypersensitivity reaction to rifamycins (rifampin, rifabutin, or rifapentine): reactions may include a flu-like syndrome (e.g. fever, chills, headaches, dizziness, musculoskeletal pain), thrombocytopenia, shortness of breath or other signs and symptoms including wheezing, acute bronchospasm, urticaria, petechiae, purpura, pruritus, conjunctivitis, angioedema, hypotension or shock.
+If moderate to severe reaction (e.g. thrombocytopenia, hypotension), hospitalization or life-threatening event: Discontinue treatment.
+If mild reaction (e.g. rash, dizziness, fever): Continue to monitor patient closely with a low threshold for discontinuing treatment.
+A flu-like syndrome appears to be the most common side effect profile leading to discontinuation of the 3HP regimen.
+Rifabutin can rarely cause uveitis." data-tooltip-position="tooltip-center">i</span> client has symptoms of adverse reactions
                     </td>
                 </tr>
                 <tr>
@@ -369,12 +393,18 @@
             </tbody>
         </table>
 
-        <table id="tab-content7" class="uk-table uk-table-small tab-content">
+        <table id="tab-content1" class="uk-table uk-table-small tab-content">
             <tbody>
                 <tr>
                     <th>Adverse Reactions</th>
                     <td>
-                        Orange discoloration of body fluids (secretions, tears, urine) , GI upset, drug interactions, hepatitis, thrombocytopenia, rash, fever, influenza-like symptoms, hypersensitivity reaction* Many drug-drug interactions
+                        Orange discoloration of body fluids (secretions, tears, urine) , GI upset, drug interactions, hepatitis, thrombocytopenia, rash, fever, influenza-like symptoms, hypersensitivity reaction <span class="info-icon" data-tooltip="NOTE: 
+
+Hypersensitivity reaction to rifamycins (rifampin, rifabutin, or rifapentine): reactions may include a flu-like syndrome (e.g. fever, chills, headaches, dizziness, musculoskeletal pain), thrombocytopenia, shortness of breath or other signs and symptoms including wheezing, acute bronchospasm, urticaria, petechiae, purpura, pruritus, conjunctivitis, angioedema, hypotension or shock.
+If moderate to severe reaction (e.g. thrombocytopenia, hypotension), hospitalization or life-threatening event: Discontinue treatment.
+If mild reaction (e.g. rash, dizziness, fever): Continue to monitor patient closely with a low threshold for discontinuing treatment.
+A flu-like syndrome appears to be the most common side effect profile leading to discontinuation of the 3HP regimen.
+Rifabutin can rarely cause uveitis." data-tooltip-position="tooltip-left">i</span> Many drug-drug interactions
                     </td>
                 </tr>
                 <tr>
@@ -383,7 +413,21 @@
                     </th>
                     <td>
                         Complete blood count (CBC), platelets and liver function tests.
-                        Repeat measurements if: * baseline results are abnormal * client has symptoms of adverse reactions  Prior to starting RIF or RPT: need to carefully review all medications being taken by the patient with LTBI and ensure there is no contraindication to the use of that medication and RIF, RBT or RPT.
+                        Repeat measurements if: <span class="info-icon" data-tooltip="NOTE:
+
+Hypersensitivity reaction to rifamycins (rifampin, rifabutin, or rifapentine): reactions may include a flu-like syndrome (e.g. fever, chills, headaches, dizziness, musculoskeletal pain), thrombocytopenia, shortness of breath or other signs and symptoms including wheezing, acute bronchospasm, urticaria, petechiae, purpura, pruritus, conjunctivitis, angioedema, hypotension or shock.
+If moderate to severe reaction (e.g. thrombocytopenia, hypotension), hospitalization or life-threatening event: Discontinue treatment.
+If mild reaction (e.g. rash, dizziness, fever): Continue to monitor patient closely with a low threshold for discontinuing treatment.
+A flu-like syndrome appears to be the most common side effect profile leading to discontinuation of the 3HP regimen.
+Rifabutin can rarely cause uveitis.
+Content
+">i</span> baseline results are abnormal <span class="info-icon" data-tooltip="NOTE:
+
+Hypersensitivity reaction to rifamycins (rifampin, rifabutin, or rifapentine): reactions may include a flu-like syndrome (e.g. fever, chills, headaches, dizziness, musculoskeletal pain), thrombocytopenia, shortness of breath or other signs and symptoms including wheezing, acute bronchospasm, urticaria, petechiae, purpura, pruritus, conjunctivitis, angioedema, hypotension or shock.
+If moderate to severe reaction (e.g. thrombocytopenia, hypotension), hospitalization or life-threatening event: Discontinue treatment.
+If mild reaction (e.g. rash, dizziness, fever): Continue to monitor patient closely with a low threshold for discontinuing treatment.
+A flu-like syndrome appears to be the most common side effect profile leading to discontinuation of the 3HP regimen.
+Rifabutin can rarely cause uveitis." data-tooltip-position="tooltip-right">i</span> client has symptoms of adverse reactions  Prior to starting RIF or RPT: need to carefully review all medications being taken by the patient with LTBI and ensure there is no contraindication to the use of that medication and RIF, RBT or RPT.
                     </td>
                 </tr>
                 <tr>
@@ -396,7 +440,7 @@
             </tbody>
         </table>
 
-        <table id="tab-content8" class="uk-table uk-table-small tab-content">
+        <table id="tab-content2" class="uk-table uk-table-small tab-content">
             <tbody>
                 <tr>
                     <th>Adverse Reactions</th>
@@ -405,7 +449,19 @@
                 <tr>
                     <th>Monitoring</th>
                     <td>Complete blood count (CBC), platelets and liver function tests.
-                        Repeat measurements if: * baseline results are abnormal * client has symptoms of adverse reactions  Prior to starting RIF or RPT: need to carefully review all medications being taken by the patient with LTBI and ensure there is no contraindication to the use of that medication and RIF or RPT.</td>
+                        Repeat measurements if: <span class="info-icon" data-tooltip="NOTE: 
+
+Hypersensitivity reaction to rifamycins (rifampin, rifabutin, or rifapentine): reactions may include a flu-like syndrome (e.g. fever, chills, headaches, dizziness, musculoskeletal pain), thrombocytopenia, shortness of breath or other signs and symptoms including wheezing, acute bronchospasm, urticaria, petechiae, purpura, pruritus, conjunctivitis, angioedema, hypotension or shock.
+If moderate to severe reaction (e.g. thrombocytopenia, hypotension), hospitalization or life-threatening event: Discontinue treatment.
+If mild reaction (e.g. rash, dizziness, fever): Continue to monitor patient closely with a low threshold for discontinuing treatment.
+A flu-like syndrome appears to be the most common side effect profile leading to discontinuation of the 3HP regimen.
+Rifabutin can rarely cause uveitis." data-tooltip-position="tooltip-center-center">i</span> baseline results are abnormal <span class="info-icon" data-tooltip="NOTE: 
+
+Hypersensitivity reaction to rifamycins (rifampin, rifabutin, or rifapentine): reactions may include a flu-like syndrome (e.g. fever, chills, headaches, dizziness, musculoskeletal pain), thrombocytopenia, shortness of breath or other signs and symptoms including wheezing, acute bronchospasm, urticaria, petechiae, purpura, pruritus, conjunctivitis, angioedema, hypotension or shock.
+If moderate to severe reaction (e.g. thrombocytopenia, hypotension), hospitalization or life-threatening event: Discontinue treatment.
+If mild reaction (e.g. rash, dizziness, fever): Continue to monitor patient closely with a low threshold for discontinuing treatment.
+A flu-like syndrome appears to be the most common side effect profile leading to discontinuation of the 3HP regimen.
+Rifabutin can rarely cause uveitis." data-tooltip-position="tooltip-bottom-center">i</span> client has symptoms of adverse reactions  Prior to starting RIF or RPT: need to carefully review all medications being taken by the patient with LTBI and ensure there is no contraindication to the use of that medication and RIF or RPT.</td>
                 </tr>
                 <tr>
                     <th>Comments</th>
@@ -425,4 +481,57 @@
 <script src="../assets/uikit.js" type="text/javascript"></script>
 <script src="../assets/uikit-icons.js" type="text/javascript"></script>
 <script src="../assets/main.js" type="text/javascript"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+    const tooltips = document.querySelectorAll(".info-icon");
+
+    document.addEventListener("click", function (event) {
+    if (!event.target.closest(".info-icon")) {
+        document
+        .querySelectorAll(".info-icon.active")
+        .forEach((activeIcon) => {
+            activeIcon.classList.remove("active");
+        });
+    }
+    });
+
+    tooltips.forEach(function (icon) {
+    let tooltip = icon.querySelector(".tooltip");
+    if (!tooltip) {
+        tooltip = document.createElement("div");
+        tooltip.className = "tooltip";
+        tooltip.textContent =
+        icon.getAttribute("data-tooltip") || "Additional information";
+
+        // Get positioning class from data attribute
+        const positionClass =
+        icon.getAttribute("data-tooltip-position") || "tooltip-center";
+        tooltip.classList.add(positionClass);
+
+        icon.appendChild(tooltip);
+    }
+
+    let isTooltipVisible = false;
+
+    icon.addEventListener("click", function (event) {
+        event.stopPropagation();
+
+        document
+        .querySelectorAll(".info-icon.active")
+        .forEach((activeIcon) => {
+            if (activeIcon !== icon) {
+            activeIcon.classList.remove("active");
+            const otherTooltip = activeIcon.querySelector(".tooltip");
+            if (otherTooltip) otherTooltip.style.display = "none";
+            }
+        });
+
+        isTooltipVisible = !this.classList.contains("active");
+        this.classList.toggle("active");
+        tooltip.style.display = isTooltipVisible ? "block" : "none";
+    });
+    });
+});
+
+</script>
 </html>

--- a/pages/5_treatment_of_current_(active)_disease_therapy__c__special_clinical_situations.html
+++ b/pages/5_treatment_of_current_(active)_disease_therapy__c__special_clinical_situations.html
@@ -50,10 +50,8 @@
         <li><a href="#table7">Table 7. Treatment of Adults and Children with Drug Susceptible Pulmonary TB </a></li>
         <li><a href="#figure1">Figure 1. Factors to be considered in deciding to initiate treatment empirically for active TB</a></li>
         <li><a href="#table8">Table 8. First-Line TB Drugs: Dosing for Adults</a></li>
-        <li><a href="#table9">Table 9. Pediatric Dosages - Isoniazid in Children</a></li>
-        <li><a href="#table10">Table 10. Pediatric Dosages - Rifampin in Children</a></li>
-        <li><a href="#table11">Table 11. Pediatric Dosages - Ethambutol in Children</a></li>
-        <li><a href="#table12">Table 12. Pediatric Dosages - Pyrazinamide in Children</a></li>
+        <li><a href="#table9">Table 9. Pediatric Dosage in Children (Birth to 15 Years)</a></li>
+
         <li><a href="#table13">Table 13. Antituberculosis Antibiotics in Adult Patients with Renal Impairment</a></li>
         <li><a href="#table14">Table 14. Medications for patients with contraindications to or intolerance of first line agents or who require IV therapy during acute or critical illness</a></li>
         <li><a href="#table15">Table 15. Clinical Situations when standard therapy cannot be given or is not well-tolerated or may not be effective</a></li>
@@ -64,105 +62,89 @@
             id="table_7_recommended_regimens_for_treatment_of_adults_and_children_with_drug_susceptible_tb_pulmonary_tb">
             <div class="uk-tabs-container">
                 <ul class="tabs">
-                    <li><button class="tab-button active-option" onclick="switchTab(0, event)">Option 1</button></li>
-                    <li><button class="tab-button" onclick="switchTab(1, event)">Option 2</button></li>
+                    <li><button class="tab-button active-option" onclick="switchTab(0, event)">Initial Phase</button></li>
+                    <li><button class="tab-button" onclick="switchTab(1, event)">Continuation Phase</button></li>
                 </ul>
             </div>
     
-            <div id="content0" class="option-content active-option">
-                <span class="duration">Total Duration: 6 months^</span>
-    
-                <h3 class="highlight">Initial Phase</h3>
-    
-                <table class="uk-table uk-table-small">
-                    <tbody>
-                        <tr>
-                            <th colspan="2">Drug</th>
-                            <td colspan="2">Isoniazid Rifampin Pyrazinamide Ethambutol</td>
-                        </tr>
-                        <tr>
-                            <th colspan="2">Interval & Dose # (minimal duration)</th>
-                            <td colspan="2">Daily DOT for 40 doses (8 weeks)</td>
-                        </tr>
-                    </tbody>
-                </table>
-    
-                <h3 class="highlight">Continuation Phase</h3>
-    
-                <table class="uk-table uk-table-small">
-                    <tbody>
-                        <tr>
-                            <th colspan="2">Drug</th>
-                            <td colspan="2">Isoniazid Rifampin Vitamin B6</td>
-                            <td colspan="2">Isoniazid Rifampin</td>
-                        </tr>
-                        <tr>
-                            <th colspan="2" class="uk-table-expand">Interval & Dose # (minimal duration)</th>
-                            <td colspan="2">1a. Daily DOT for 90 doses (18 weeks)</td>
-                            <td colspan="2">1b. Thrice weekly DOT for 54 doses (18 weeks)</td>
-                        </tr>
-                        <tr>
-                            <th rowspan="2" class="uk-table-expand">Comments</th>
-                            <td colspan="2">Regimen must given by DOT.</td>
-                            <td colspan="2">Continue ethambutol until susceptibility to isoniazid and rifampin is demonstrated</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-    
-            <div id="content1" class="option-content">
-                <span class="duration">Total Duration: 6 months^</span>
-    
-                <h3 class="highlight">Initial Phase</h3>
-    
-                <table class="uk-table uk-table-small">
-                    <tbody>
-                        <tr>
-                            <th colspan="2">Drug</th>
-                            <td colspan="2">Isoniazid Rifampin Pyrazinamide Ethambutol Vitamin B6</td>
-                        </tr>
-                        <tr>
-                            <th colspan="2">Interval & Dose # (minimal duration)</th>
-                            <td colspan="2">Daily DOT for 10 doses (2 weeks) then twice weekly DOT for 12 doses (6 weeks)</td>
-                        </tr>
-                    </tbody>
-                </table>
-    
-                <h3 class="highlight">Continuation Phase</h3>
-    
-                <table class="uk-table uk-table-small">
-                    <tbody>
-                        <tr>
-                            <th class="uk-table-expand">Drug</th>
-                            <td>Isoniazid Rifampin Vitamin B6</td>
-                        </tr>
-                        <tr>
-                            <th class="uk-table-expand">Interval & Dose # (minimal duration)</th>
-                            <td>2a. Twice weekly DOT for 36 doses (18 weeks)</td>
-                        </tr>
-                        <tr>
-                            <th class="uk-table-expand">Comments</th>
-                            <td>We do not recommend this regimen. If used, it must be given by DOT. Include ethambutol in the initial phase. After the initial phase, continue ethambutol until susceptibility to INH and rigampin is demonstrated</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+  <div id="content0" class="option-content active-option">
+            <h4 class="duration with-info-icon">Total Duration (Initial + Continuation): 6 months<span class="info-icon" data-tooltip="NOTE: Duration of therapy for patients with drug-susceptible TB should be extended to 9 months (31 weeks continuation phase, 39 weeks total) for patients who have cavitary pulmonary TB and remain sputum culture positive after 2 months of therapy.
+Many experts would extend therapy to 9 months for all patients with HIV/TB, especially those slow to convert to negative cultures or not on effective HIV treatment." data-tooltip-position="tooltip-bottom-center">i</span></h4>
 
-            <p>Table 7 Notes</p>
-            <p>NOTE: 1 Daily DOT = 5 days/week (Monday through Friday). Self administered doses (including those on
-                weekends) will not be counted toward the total doses.</p>
-            <p>NOTE 2: Regimen 1a is the preferred regimen for patients with newly diagnosed TB.</p>
-            <p>NOTE 3: Pyridoxine (Vitamin B6) 25 - 50 mg/daily should be added to all regimens that include isoniazid
-                (INH) in adults to prevent development of INH- induced peripheral neuropathy. For patients with pre-existing
-                peripheral neuropathy, increase pyridoxine dose to 100 mg/day unless there is abnormal renal function.</p>
-            <p>^NOTE: Duration of therapy for patients with drug-susceptible TB should be extended to 9 months (31 weeks
-                continuation phase, 39 weeks total) for patients who have cavitary pulmonary TB and remain sputum culture
-                positive after 2 months of therapy. Many experts would extend therapy to 9 months for all patients with
-                HIV/TB, especially those slow to convert to negative cultures or not on effective HIV treatment.</p>
-            <p>*NOTE: Option 2 should NOT be used for patients living with HIV, cavitary pulmonary TB, disseminated TB, vertebral TB or for patients who have co-morbid medical conditions such as diabetes mellitus, end- stage renal disease or liver disease.</p>
-            <p>NOTE: Split dosing should be avoided.</p>
-            <p>NOTE: Refer to current drug reference or drug package insert for a complete
-                list of adverse drug reactions and drug interaction.</p>
+            <table class="uk-table uk-table-small">
+                <tbody>
+                    <tr>
+                        <th colspan="2">Drug</th>
+                        <td colspan="2">Isoniazid + Pyridoxine (Vitamin B6) <br>
+                                        Rifampin <span class="info-icon" data-tooltip="NOTE: 
+
+Pyridoxine (Vitamin B6) 25–50 mg/daily should be added to all regimens that include isoniazid (INH) in adults to prevent development of INH-induced peripheral neuropathy.
+For patients with pre-existing peripheral neuropathy, increase pyridoxine dose to 100 mg/day unless there is abnormal renal function.">i</span><br>
+                                        Pyrazinamide <br>
+                                        Ethambutol
+                        </td>
+                    </tr>
+                    <tr>
+                        <th colspan="2">Interval & Dose # </th>
+                        <td colspan="2" >Daily DOT <span class="info-icon" data-tooltip="NOTE: Daily DOT = 5 days/week (Monday through Friday). Self administered doses (including those on weekends) will not be counted toward the total doses.">i</span> for 40 doses</td>
+                    </tr>
+                    <tr>
+                        <th colspan="2">Minimal Duration</th>
+                        <td colspan="2">8 weeks</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div id="content1" class="option-content">
+            <h4 class="duration with-info-icon">Total Duration (Initial + Continuation): 6 months<span class="info-icon" data-tooltip="NOTE:
+
+Duration of therapy for patients with drug-susceptible TB should be extended to 9 months (31 weeks continuation phase, 39 weeks total) for patients who have cavitary pulmonary TB and remain sputum culture positive after 2 months of therapy.
+Many experts would extend therapy to 9 months for all patients with HIV/TB, especially those slow to convert to negative cultures or not on effective HIV treatment."  data-tooltip-position="tooltip-bottom-center">i</span></h4>
+
+                        <table class="uk-table uk-table-small">
+                <tbody>
+                    <tr>
+                        <th colspan="1">Regimen</th>
+                        <td colspan="1">Regimen 1a <span class="info-icon" data-tooltip="NOTE: Regimen 1a is the preferred regimen for patients with newly diagnosed TB.">i</span></td>
+                        <td colspan="1">Regimen 1b</td>
+                    </tr>
+                    <tr>
+                        <th colspan="1">Drug</th>
+                        <td colspan="">Isoniazid + <br> Pyridoxine (Vitamin B6) <span class="info-icon" data-tooltip="NOTE: 
+
+Pyridoxine (Vitamin B6) 25–50 mg/daily should be added to all regimens that include isoniazid (INH) in adults to prevent development of INH-induced peripheral neuropathy.
+For patients with pre-existing peripheral neuropathy, increase pyridoxine dose to 100 mg/day unless there is abnormal renal function.">i</span> <br>
+                                        Rifampin </td>
+                        <td colspan="1">Isoniazid + <br> Pyridoxine (Vitamin B6) <span class="info-icon" data-tooltip="NOTE:
+
+Pyridoxine (Vitamin B6) 25–50 mg/daily should be added to all regimens that include isoniazid (INH) in adults to prevent development of INH-induced peripheral neuropathy.
+For patients with pre-existing peripheral neuropathy, increase pyridoxine dose to 100 mg/day unless there is abnormal renal function."  data-tooltip-position="tooltip-left">i</span> <br>
+                                        Rifampin</td>
+                    </tr>
+                    <tr>
+                        <th colspan="1">Interval & Dose #</th>
+                        <td colspan="1">Daily DOT <span class="info-icon" data-tooltip="NOTE: Daily DOT = 5 days/week (Monday through Friday). Self administered doses (including those on weekends) will not be counted toward the total doses.">i</span> for 90 doses</td>
+                        <td colspan="1">Thrice weekly DOT for 54 doses</td>
+                    </tr>
+                    <tr>
+                        <th colspan="1">Minimal Duration</th>
+                        <td colspan="1">18 weeks</td>
+                        <td colspan="1">18 weeks</td>
+                    </tr>
+                    <tr>
+                        <th colspan="1">Comments</th>
+                        <td colspan="1">Any regimen must given by DOT.</td>
+                        <td colspan="1">Continue ethambutol until susceptibility to isoniazid and rifampin is demonstrated</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <p>Additional Note: <br>
+            1. Split dosing should be avoided. <br>
+            2. Refer to current drug reference or drug package insert for a complete list of adverse drug reactions and drug interaction.
+        </p>
         </div>
         
     <h4 id="figure1">Figure 1. Factors to be considered in deciding to initiate treatment empirically for active tuberculosis (TB) (prior
@@ -193,201 +175,206 @@
                         <li><button class="tab-button active-option" onclick="switchTab(2, event)"> Isoniazid</button></li>
                         <li><button class="tab-button" onclick="switchTab(3, event)"> Rifampin</button></li>
                         <li><button class="tab-button" onclick="switchTab(4, event)"> Rifabutin</button></li>
-                        <li><button class="tab-button" onclick="switchTab(5, event)"> Pyrazinamide**</button></li>
-                        <li><button class="tab-button" onclick="switchTab(6, event)"> Ethambutol**</button></li>
+                        <li><button class="tab-button" onclick="switchTab(5, event)"> Pyrazinamide¹</button></li>
+                        <li><button class="tab-button" onclick="switchTab(6, event)"> Ethambutol¹</button></li>
                     </ul>
                 </div>
         
-                <div id="content2" class="option-content active-option">
-                    <table class="uk-table uk-table-small uk-table-divider">
-                        <tbody>
-                            <tr>
-                                <th class="uk-table-shrink">Frequency</th>
-                                <td>Daily</td>
-                                <td>Thrice-Weekly</td>
-                            </tr>
-                            <tr>
-                                <th class="uk-table-shrink">Adult Dose based on body weight in kilograms (kg)*</th>
-                                <td>300 mg</td>
-                                <td>900 mg</td>
-                            </tr>
-                            <tr>
-                                <th class="uk-table-shrink">Adverse Reactions</th>
-                                <td colspan="2">
-                                    <ul>
-                                        <li>Gastrointestinal (GI) upset</li>
-                                        <li>Liver enzyme elevation</li>
-                                        <li>Hepatitis</li>
-                                        <li>Mild effects on central nervous</li>
-                                        <li>Drug interactions</li>
-                                    </ul>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-        
-                <div id="content3" class="option-content">
-                    <table class="uk-table uk-table-small uk-table-divider">
-                        <tbody>
-                            <tr>
-                                <th class="uk-table-shrink">Frequency</th>
-                                <td>Daily</td>
-                                <td>Thrice-Weekly</td>
-                            </tr>
-                            <tr>
-                                <th class="uk-table-shrink">Adult Dose based on body weight in kilograms (kg)*</th>
-                                <td>600 mg</td>
-                                <td>600 mg</td>
-                            </tr>
-                            <tr>
-                                <th class="uk-table-shrink">Adverse Reactions</th>
-                                <td colspan="2">
-                                    <ul>
-                                        <li>Orange discoloration of body fluids and secretions</li>
-                                        <li>Drug interactions</li>
-                                        <li>GI upset</li>
-                                        <li>Hepatitis</li>
-                                        <li>Bleeding problems</li>
-                                        <li>Influenze-like symptoms</li>
-                                        <li>Rash</li>
-                                        <li>Uveitis (rifabutin only)</li>
-                                    </ul>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-        
-                <div id="content4" class="option-content">
-                    <table class="uk-table uk-table-small uk-table-divider">
-                        <tbody>
-                            <tr>
-                                <th class="uk-table-shrink">Frequency</th>
-                                <td>Daily</td>
-                                <td>Thrice-Weekly</td>
-                            </tr>
-                            <tr>
-                                <th class="uk-table-shrink">Adult Dose based on body weight in kilograms (kg)*</th>
-                                <td>300 mg</td>
-                                <td>Not recommended</td>
-                            </tr>
-                            <tr>
-                                <th class="uk-table-shrink">Adverse Reactions</th>
-                                <td colspan="2">
-                                    <ul>
-                                        <li>Orange discoloration of body fluids and secretions</li>
-                                        <li>Drug interactions</li>
-                                        <li>GI upset</li>
-                                        <li>Hepatitis</li>
-                                        <li>Bleeding problems</li>
-                                        <li>Influenze-like symptoms</li>
-                                        <li>Rash</li>
-                                        <li>Uveitis (rifabutin only)</li>
-                                    </ul>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-        
-                <div id="content5" class="option-content">
-                    <table class="uk-table uk-table-small uk-table-divider">
-                        <tbody>
-                            <tr>
-                                <th class="uk-table-shrink">Frequency</th>
-                                <td>Daily</td>
-                                <td>Thrice-Weekly</td>
-                            </tr>
-                            <tr>
-                                <th rowspan="3" class="uk-table-shrink">Adult Dose based on body weight in kilograms (kg)*</th>
-                                <td>40-55 kg: 1000 mg</td>
-                                <td>40-55 kg: 1500 mg</td>
-                                <tr>
-                                    <td>56-75 kg: 2500 mg</td>
-                                    <td>56-75 kg: 1500 mg</td>
-                                </tr>
-                                <tr>
-                                    <td>76+ kg: 3000 mg</td>
-                                    <td>76+ kg: 4000 mg</td>
-                                </tr>
-                            </tr>
-                            <tr>
-                                <th class="uk-table-shrink">Adverse Reactions</th>
-                                <td colspan="2">
-                                    <ul>
-                                        <li>Orange discoloration of body fluids and secretions</li>
-                                        <li>Drug interactions</li>
-                                        <li>GI upset</li>
-                                        <li>Hepatitis</li>
-                                        <li>Bleeding problems</li>
-                                        <li>Influenze-like symptoms</li>
-                                        <li>Rash</li>
-                                        <li>Uveitis (rifabutin only)</li>
-                                    </ul>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-        
-                <div id="content6" class="option-content">
-                    <table class="uk-table uk-table-small uk-table-divider">
-                        <tbody>
-                            <tr>
-                                <th class="uk-table-shrink">Frequency</th>
-                                <td>Daily</td>
-                                <td>Thrice-Weekly</td>
-                            </tr>
-                            <tr>
-                                <th rowspan="3" class="uk-table-shrink">Adult Dose based on body weight in kilograms (kg)*</th>
-                                <td>40-55 kg: 800 mg</td>
-                                <td>40-55 kg: 1200 mg</td>
-                                <tr>
-                                    <td>56-75 kg: 1200 mg</td>
-                                    <td>56-75 kg: 2000 mg</td>
-                                </tr>
-                                <tr>
-                                    <td>76+ kg: 1600 mg</td>
-                                    <td>76+ kg: 2400 mg</td>
-                                </tr>
-                            </tr>
-                            <tr>
-                                <th class="uk-table-shrink">Adverse Reactions</th>
-                                <td colspan="2">
-                                    <ul>
-                                        <li>Optic neuritis</li>
-                                    </ul>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
+       <div id="content0" class="option-content active-option">
+            <table class="uk-table uk-table-small uk-table-divider">
+                <tbody>
+                    <tr>
+                        <th class="uk-table-shrink">Frequency</th>
+                        <td>Daily</td>
+                        <td>Thrice-Weekly</td>
+                    </tr>
+                    <tr>
+                        <th class="uk-table-shrink">Adult Dose based on body weight in kilograms (kg) <span class="info-icon" data-tooltip="NOTE: Formula used to convert pounds to kilograms: Divide pounds by 2.2 to get kilograms. Example: Patient weighs 154 pounds ÷ 2.2 = 70 kilograms."  data-tooltip-position="tooltip-right">i</span></th>
+                        <td>300 mg</td>
+                        <td>900 mg</td>
+                    </tr>
+                    <tr>
+                        <th class="uk-table-shrink">Adverse Reactions</th>
+                        <td colspan="2">
+                            <ul>
+                                <li>Gastrointestinal (GI) upset</li>
+                                <li>Liver enzyme elevation</li>
+                                <li>Hepatitis</li>
+                                <li>Mild effects on central nervous</li>
+                                <li>Drug interactions</li>
+                            </ul>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
 
-            <p>*Formula used to convert pounds to kilograms: Divide pounds by 2.2 to get kilograms.</p>
-            <p>Example: Patient weighs 154 pounds ÷ 2.2 = 70 kilograms.</p>
-            <p>** Calculate pyrazinamide and ethambutol doses using actual body weight. Pyrazinamide and ethambutol dosage
-                adjustment is needed in patients with estimated creatinine clearance less than 50 ml/min or those with
-                end-stage renal disease on dialysis.</p>
-            <p>NOTE: Refer to current drug reference or drug package insert for a complete list of adverse drug reactions
-                and drug interactions.</p>
+        <div id="content1" class="option-content">
+            <table class="uk-table uk-table-small uk-table-divider">
+                <tbody>
+                    <tr>
+                        <th class="uk-table-shrink">Frequency</th>
+                        <td>Daily</td>
+                        <td>Thrice-Weekly</td>
+                    </tr>
+                    <tr>
+                        <th class="uk-table-shrink">Adult Dose based on body weight in kilograms (kg) <span class="info-icon" data-tooltip="NOTE: Formula used to convert pounds to kilograms: Divide pounds by 2.2 to get kilograms. Example: Patient weighs 154 pounds ÷ 2.2 = 70 kilograms." data-tooltip-position="tooltip-right">i</span></th>
+                        <td>600 mg</td>
+                        <td>600 mg</td>
+                    </tr>
+                    <tr>
+                        <th class="uk-table-shrink">Adverse Reactions</th>
+                        <td colspan="2">
+                            <ul>
+                                <li>Orange discoloration of body fluids and secretions</li>
+                                <li>Drug interactions</li>
+                                <li>GI upset</li>
+                                <li>Hepatitis</li>
+                                <li>Bleeding problems</li>
+                                <li>Influenze-like symptoms</li>
+                                <li>Rash</li>
+                                <li>Uveitis (rifabutin only)</li>
+                            </ul>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
 
+        <div id="content2" class="option-content">
+            <table class="uk-table uk-table-small uk-table-divider">
+                <tbody>
+                    <tr>
+                        <th class="uk-table-shrink">Frequency</th>
+                        <td>Daily</td>
+                        <td>Thrice-Weekly</td>
+                    </tr>
+                    <tr>
+                        <th class="uk-table-shrink">Adult Dose based on body weight in kilograms (kg) <span class="info-icon" data-tooltip="NOTE: Formula used to convert pounds to kilograms: Divide pounds by 2.2 to get kilograms. Example: Patient weighs 154 pounds ÷ 2.2 = 70 kilograms." data-tooltip-position="tooltip-right">i</span></th>
+                        <td>300 mg</td>
+                        <td>Not recommended</td>
+                    </tr>
+                    <tr>
+                        <th class="uk-table-shrink">Adverse Reactions</th>
+                        <td colspan="2">
+                            <ul>
+                                <li>Orange discoloration of body fluids and secretions</li>
+                                <li>Drug interactions</li>
+                                <li>GI upset</li>
+                                <li>Hepatitis</li>
+                                <li>Bleeding problems</li>
+                                <li>Influenze-like symptoms</li>
+                                <li>Rash</li>
+                                <li>Uveitis (rifabutin only)</li>
+                            </ul>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div id="content3" class="option-content">
+            <table class="uk-table uk-table-small uk-table-divider">
+                <tbody>
+                    <tr>
+                        <th class="uk-table-shrink">Frequency</th>
+                        <td>Daily</td>
+                        <td>Thrice-Weekly</td>
+                    </tr>
+                    <tr>
+                        <th rowspan="3" class="uk-table-shrink">Adult Dose based on body weight in kilograms (kg) <span class="info-icon" data-tooltip="NOTE: Formula used to convert pounds to kilograms: Divide pounds by 2.2 to get kilograms.Example: Patient weighs 154 pounds ÷ 2.2 = 70 kilograms." data-tooltip-position="tooltip-right">i</span></th>
+                        <td>40-55 kg: 1000 mg</td>
+                        <td>40-55 kg: 1500 mg</td>
+                        <tr>
+                            <td>56-75 kg: 2500 mg</td>
+                            <td>56-75 kg: 1500 mg</td>
+                        </tr>
+                        <tr>
+                            <td>76+ kg: 3000 mg</td>
+                            <td>76+ kg: 4000 mg</td>
+                        </tr>
+                    </tr>
+                    <tr>
+                        <th class="uk-table-shrink">Adverse Reactions</th>
+                        <td colspan="2">
+                            <ul>
+                                <li>Orange discoloration of body fluids and secretions</li>
+                                <li>Drug interactions</li>
+                                <li>GI upset</li>
+                                <li>Hepatitis</li>
+                                <li>Bleeding problems</li>
+                                <li>Influenze-like symptoms</li>
+                                <li>Rash</li>
+                                <li>Uveitis (rifabutin only)</li>
+                            </ul>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div id="content4" class="option-content">
+            <table class="uk-table uk-table-small uk-table-divider">
+                <tbody>
+                    <tr>
+                        <th class="uk-table-shrink">Frequency</th>
+                        <td>Daily</td>
+                        <td>Thrice-Weekly</td>
+                    </tr>
+                    <tr>
+                        <th rowspan="3" class="uk-table-shrink">Adult Dose based on body weight in kilograms (kg) <span class="info-icon" data-tooltip="NOTE: Formula used to convert pounds to kilograms: Divide pounds by 2.2 to get kilograms. Example: Patient weighs 154 pounds ÷ 2.2 = 70 kilograms." data-tooltip-position="tooltip-right">i</span></th>
+                        <td>40-55 kg: 800 mg</td>
+                        <td>40-55 kg: 1200 mg</td>
+                        <tr>
+                            <td>56-75 kg: 1200 mg</td>
+                            <td>56-75 kg: 2000 mg</td>
+                        </tr>
+                        <tr>
+                            <td>76+ kg: 1600 mg</td>
+                            <td>76+ kg: 2400 mg</td>
+                        </tr>
+                    </tr>
+                    <tr>
+                        <th class="uk-table-shrink">Adverse Reactions</th>
+                        <td colspan="2">
+                            <ul>
+                                <li>Optic neuritis</li>
+                            </ul>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <ol>
+            <li>Calculate pyrazinamide and ethambutol doses using actual body weight. Pyrazinamide and ethambutol dosage adjustment is needed in patients with estimated creatinine clearance less than 50 ml/min or those with end-stage renal disease on dialysis.</li>
+        </ol>
+
+        <p>Additional Note: Refer to current drug reference or drug package insert for a complete list of adverse drug reactions and drug interactions.</p>
+        
+        <p>Source: <a href="https://academic.oup.com/cid/article/63/7/e147/2196792?login=trueas">https://academic.oup.com/cid/article/63/7/e147/2196792?login=trueas</a></p>
 
         </div>
     </div>
 
-    <h4 id="table9" class="custom-table-title">Table 9: Pediatric Dosage - Isoniazid in Children (birth to 15 years)</h4>
+    <h4 id="table_9_pediatric_dosage_isoniazid_in_children_(birth_to_15_years)" class="custom-table-title">Table 9: Pediatric Dosage in Children (Birth to 15 Years)</h4>
+    <div class="uk-overflow-auto">
+      <div class="uk-tabs-container">
+            <ul class="tabs">
+                <li><button class="tab-button active-option" onclick="switchTab(0, event)"> Isoniazid</button></li>
+                <li><button class="tab-button" onclick="switchTab(1, event)"> Rifampin</button></li>
+                <li><button class="tab-button" onclick="switchTab(2, event)"> Ethambutol</button></li>
+                <li><button class="tab-button" onclick="switchTab(3, event)"> Pyrazinamide</button></li>
+            </ul>
+        </div>
 
-    <div class="uk-container">
-        
-        <div class="uk-overflow-auto"
-                id="table_9_pediatric_dosage_isoniazid_in_children_(birth_to_15_years)">
+        <div id="content0" class="option-content active-option">   
             <table class="uk-table uk-table-small uk-table-divider">
                 <thead>
                 <tr>
-                    <th class="uk-table-expand">Child's Weight (lbs)</th>
-                    <th class="uk-table-expand">Child's Weight (kg)</th>
-                    <th class="uk-table-expand">Daily Dose (mg) 10-15 mg/kg PO</th>
+                    <th>Child's Weight (lbs)</th>
+                    <th>Child's Weight (kg)</th>
+                    <th>Daily Dose (mg) 10-15 mg/kg PO</th>
                     <!-- <th class="uk-table-expand">Twice-weekly Dose (mg) 20-30 mg/kg PO</th> -->
                 </tr>
                 </thead>
@@ -494,32 +481,27 @@
                     <!-- <td>900 mg PO</td> -->
                 </tr>
             </table>
-
+    
             <p>NOTE: Isoniazid tablets come in 50 mg, 100mg, 300 mg sizes and can be crushed for oral administration.
                 Isoniazid tablets are also scored.</p>
             <p>Isoniazid Syrup (50mg/5ml) should not be refrigerated. It contains sorbitol and will cause diarrhea. It
                 should be used only when crushed tablets cannot accommodate the situation. (keep at room temperature).</p>
-
         </div>
-    </div>
-
-
-    <h4 id="table10" class="custom-table-title">Table 10. Pediatric Dosages - Rifampin in Children (birth to 15 years)</h4>
-    <div class="uk-container">  
-        <div class="uk-overflow-auto"
-                id="table_10_pediatric_dosages_rifampin_in_children_(birth_to_15_years)">
-            <table class="uk-table uk-table-small uk-table-divider">
-                <thead>
+        
+        <div id="content1" class="option-content">
+            <div id="table_10_pediatric_dosages_rifampin_in_children_(birth_to_15_years)">
+                <table class="uk-table uk-table-small uk-table-divider">
+                    <thead>
                     <tr>
-                        <th class="uk-table-expand">Child's Weight (lbs)</th>
-                        <th class="uk-table-expand">Child's Weight (kg)</th>
-                        <th class="uk-table-expand">Dose (mg) 10-20 mg/kg</th>
-                        
+                        <th>Child's Weight (lbs)</th>
+                        <th>Child's Weight (kg)</th>
+                        <th>Daily Dose (mg) 10-20 mg/kg</th>
                     </tr>
                     </thead>
+                
                     <tr>
                         <td>15 - 32</td>
-                        <td>7 - 14.5</td>
+                        <td> 7 - 14.5</td>
                         <td>150 mg</td>
                     </tr>
                     <tr>
@@ -537,168 +519,151 @@
                         <td>30 +</td>
                         <td>600 mg</td>
                     </tr>
-            </table>
+                </table>
+            </div>
         </div>
-    </div>
-
-
-    <h4 id="table11" class="custom-table-title">Table 11: Pediatric Dosages - Ethambutol in Children (birth to 15 years)</h4>
-    <div class="uk-container">
-        <div class="uk-overflow-auto"
-                id="table_11_pediatric_dosages_ethambutol_in_children_(birth_to_15_years)">
-            <table class="uk-table uk-table-small uk-table-divider">
-                <thead>
-                <tr>
-                    <th>Child’s Weight (lbs)</th>
-                    <th>Child’s Weight (kg)</th>
-                    <th>Daily Dose (mg) 15 – 25 mg/kg</th>
-                </tr>
-                </thead>
-                <tr>
-                    <td>11 – 15</td>
-                    <td>5 – 7</td>
-                    <td>100 mg</td>
-                </tr>
-                <tr>
-                    <td>16 – 31</td>
-                    <td>8 – 14</td>
-                    <td>200 mg</td>
-                </tr>
-                <tr>
-                    <td>32 – 44</td>
-                    <td>15 – 20</td>
-                    <td>300 mg</td>
-                </tr>
-                <tr>
-                    <td>45 – 55</td>
-                    <td>21 – 25</td>
-                    <td>400 mg</td>
-                </tr>
-                <tr>
-                    <td>56 – 67</td>
-                    <td>26 – 30.5</td>
-                    <td>500 mg</td>
-                </tr>
-                <tr>
-                    <td>68 – 76</td>
-                    <td>31 – 34.5</td>
-                    <td>600 mg</td>
-                </tr>
-                <tr>
-                    <td>77 – 87</td>
-                    <td>35 – 39.5</td>
-                    <td>700 mg</td>
-                </tr>
-                <tr>
-                    <td>88 – 121</td>
-                    <td>40 – 55</td>
-                    <td>800 mg</td>
-                </tr>
-                <tr>
-                    <td>122 – 165</td>
-                    <td>56 – 75</td>
-                    <td>1200 mg</td>
-                </tr>
-                <tr>
-                    <td>166 +</td>
-                    <td>76 +</td>
-                    <td>1600 mg</td>
-                </tr>
-            </table>
-            <p>
-                The maximum recommendation for ethambutol is 1 g daily.
-            </p>
-        </div>
-    </div>
-
-
-    <h4 id="table12" class="custom-table-title">Table 12: Pediatric Dosages - Pyrazinamide in Children (birth to 15 years)</h4>
-    <div class="uk-container">
         
-        <div class="uk-overflow-auto"
-                id="table_12_pediatric_dosages_pyrazinamide_in_children_(birth_to_15_years)">
-            <table class="uk-table uk-table-small uk-table-divider">
-                <thead>
-                <tr>
-                    <th class="uk-table-expand">Child's Weight (lbs)</th>
-                    <th class="uk-table-expand">Child's Weight (kg)</th>
-                    <th class="uk-table-expand">Daily Dose (mg) 30-40 mg/kg PO</th>
-                 
-                </tr>
-                </thead>
-                <tr>
-                    <td>13 - 23</td>
-                    <td>6 - 10.5</td>
-                    <td>250 mg</td>
-                  
-                </tr>
-                <tr>
-                    <td>24 - 26</td>
-                    <td>11 - 12</td>
-                    <td>250 mg</td>
-                   
-                </tr>
-                <tr>
-                    <td>27 - 31</td>
-                    <td>12.5 - 14</td>
-                    <td>500 mg</td>
-                  
-                </tr>
-                <tr>
-                    <td>32 - 41</td>
-                    <td>14.5 - 18.5</td>
-                    <td>500 mg</td>
-                 
-                </tr>
-                <tr>
-                    <td>42 - 47</td>
-                    <td>19.0 - 21.5</td>
-                    <td>750 mg</td>
-                  
-                </tr>
-                <tr>
-                    <td>48 - 54</td>
-                    <td>22.0 - 24.5</td>
-                    <td>750 mg</td>
-                   
-                </tr>
-                <tr>
-                    <td>55 – 63</td>
-                    <td>25 – 28.5</td>
-                    <td>1000 mg</td>
-                 
-                </tr>
-                <tr>
-                    <td>64 – 67</td>
-                    <td>29 – 30.5</td>
-                    <td>1000 mg</td>
+        <div id="content2" class="option-content"> 
+            <div id="table_11_pediatric_dosages_ethambutol_in_children_(birth_to_15_years)">
+                <table class="uk-table uk-table-small uk-table-divider">
+                    <thead>
+                    <tr>
+                        <th>Child’s Weight (lbs)</th>
+                        <th>Child’s Weight (kg)</th>
+                        <th>Daily Dose (mg) 15 – 25 mg/kg</th>
+                    </tr>
+                    </thead>
+                    <tr>
+                        <td>11 – 15</td>
+                        <td>5 – 7</td>
+                        <td>100 mg</td>
+                    </tr>
+                    <tr>
+                        <td>16 – 31</td>
+                        <td>8 – 14</td>
+                        <td>200 mg</td>
+                    </tr>
+                    <tr>
+                        <td>32 – 44</td>
+                        <td>15 – 20</td>
+                        <td>300 mg</td>
+                    </tr>
+                    <tr>
+                        <td>45 – 55</td>
+                        <td>21 – 25</td>
+                        <td>400 mg</td>
+                    </tr>
+                    <tr>
+                        <td>56 – 67</td>
+                        <td>26 – 30.5</td>
+                        <td>500 mg</td>
+                    </tr>
+                    <tr>
+                        <td>68 – 76</td>
+                        <td>31 – 34.5</td>
+                        <td>600 mg</td>
+                    </tr>
+                    <tr>
+                        <td>77 – 87</td>
+                        <td>35 – 39.5</td>
+                        <td>700 mg</td>
+                    </tr>
+                    <tr>
+                        <td>88 – 121</td>
+                        <td>40 – 55</td>
+                        <td>800 mg</td>
+                    </tr>
+                    <tr>
+                        <td>122 – 165</td>
+                        <td>56 – 75</td>
+                        <td>1200 mg</td>
+                    </tr>
+                    <tr>
+                        <td>166 +</td>
+                        <td>76 +</td>
+                        <td>1600 mg</td>
+                    </tr>
+                </table>
+                <p>Additional Notes: <br>
+                    The maximum recommendation for ethambutol is 1g daily.
+                </p>
+            </div>
+        </div>
+        
+        <div id="content3" class="option-content">
+            <div id="table_12_pediatric_dosages_pyrazinamide_in_children_(birth_to_15_years)">
+                <table class="uk-table uk-table-small uk-table-divider">
+                    <thead>
+                        <tr>
+                            <th>Child's Weight (lbs)</th>
+                            <th>Child's Weight (kg)</th>
+                            <th>Daily Dose (mg) 30-40 mg/kg </th>
+                        </tr>
+                    </thead>
+                    <tr>
+                        <td>13 - 23</td>
+                        <td>6 - 10.5</td>
+                        <td>250 mg</td>
+                    </tr>
+                    <tr>
+                        <td>24 - 26</td>
+                        <td>11 - 12</td>
+                        <td>250 mg</td>
+                    </tr>
+                    <tr>
+                        <td>27 - 31</td>
+                        <td>12.5 - 14</td>
+                        <td>500 mg</td>
+                    </tr>
+                    <tr>
+                        <td>32 - 41</td>
+                        <td>14.5 - 18.5</td>
+                        <td>500 mg</td>
+                
+                    </tr>
+                    <tr>
+                        <td>42 - 47</td>
+                        <td>19.0 - 21.5</td>
+                        <td>750 mg</td>
                     
-                </tr>
-                <tr>
-                    <td>68 – 80</td>
-                    <td>31 – 36.5</td>
-                    <td>1250 mg</td>
-                    
-                </tr>
-                <tr>
-                    <td>81 – 93</td>
-                    <td>37 – 42.5</td>
-                    <td>1500 mg</td>
-                   
-                </tr>
-                <tr>
-                    <td>94 – 106</td>
-                    <td>43 – 48.5</td>
-                    <td>1750 mg</td>
-                 
-                </tr>
-                <tr>
-                    <td>107 +</td>
-                    <td>49 +</td>
-                    <td>2000 mg</td>
-                 
-                </tr>
-            </table>
+                    </tr>
+                    <tr>
+                        <td>48 - 54</td>
+                        <td>22.0 - 24.5</td>
+                        <td>750 mg</td>
+                    </tr>
+                    <tr>
+                        <td>55 – 63</td>
+                        <td>25 – 28.5</td>
+                        <td>1000 mg</td>
+                    </tr>
+                    <tr>
+                        <td>64 – 67</td>
+                        <td>29 – 30.5</td>
+                        <td>1000 mg</td>
+                    </tr>
+                    <tr>
+                        <td>68 – 80</td>
+                        <td>31 – 36.5</td>
+                        <td>1250 mg</td>
+                    </tr>
+                    <tr>
+                        <td>81 – 93</td>
+                        <td>37 – 42.5</td>
+                        <td>1500 mg</td>
+                    </tr>
+                    <tr>
+                        <td>94 – 106</td>
+                        <td>43 – 48.5</td>
+                        <td>1750 mg</td>
+                    </tr>
+                    <tr>
+                        <td>107 +</td>
+                        <td>49 +</td>
+                        <td>2000 mg</td>
+                    </tr>
+                </table>
+            </div>
         </div>
     </div>
 
@@ -1200,4 +1165,57 @@
 <script src="../assets/uikit.js" type="text/javascript"></script>
 <script src="../assets/uikit-icons.js" type="text/javascript"></script>
 <script src="../assets/main.js" type="text/javascript"></script>
+<script>
+document.addEventListener("DOMContentLoaded", function () {
+    const tooltips = document.querySelectorAll(".info-icon");
+
+    document.addEventListener("click", function (event) {
+    if (!event.target.closest(".info-icon")) {
+        document
+        .querySelectorAll(".info-icon.active")
+        .forEach((activeIcon) => {
+            activeIcon.classList.remove("active");
+        });
+    }
+    });
+
+    tooltips.forEach(function (icon) {
+    let tooltip = icon.querySelector(".tooltip");
+    if (!tooltip) {
+        tooltip = document.createElement("div");
+        tooltip.className = "tooltip";
+        tooltip.textContent =
+        icon.getAttribute("data-tooltip") || "Additional information";
+
+        // Get positioning class from data attribute
+        const positionClass =
+        icon.getAttribute("data-tooltip-position") || "tooltip-center";
+        tooltip.classList.add(positionClass);
+
+        icon.appendChild(tooltip);
+    }
+
+    let isTooltipVisible = false;
+
+    icon.addEventListener("click", function (event) {
+        event.stopPropagation();
+
+        document
+        .querySelectorAll(".info-icon.active")
+        .forEach((activeIcon) => {
+            if (activeIcon !== icon) {
+            activeIcon.classList.remove("active");
+            const otherTooltip = activeIcon.querySelector(".tooltip");
+            if (otherTooltip) otherTooltip.style.display = "none";
+            }
+        });
+
+        isTooltipVisible = !this.classList.contains("active");
+        this.classList.toggle("active");
+        tooltip.style.display = isTooltipVisible ? "block" : "none";
+    });
+    });
+});
+
+</script>
 </html>

--- a/pages/table_1_interpretation_criteria_for_the_quantiferon_tb_gold_plus_test.html
+++ b/pages/table_1_interpretation_criteria_for_the_quantiferon_tb_gold_plus_test.html
@@ -36,7 +36,7 @@
             </ul>
         </div>
 
-                <table id="tab-content0" class="uk-table uk-table-small tab-content active-tab">
+        <table id="tab-content0" class="uk-table uk-table-small tab-content active-tab">
             <tbody>
                 <tr>
                     <th>Nil (IU/ml)</th>

--- a/pages/table_2_interpretation_criteria_for_the_t_spot_tb_test.html
+++ b/pages/table_2_interpretation_criteria_for_the_t_spot_tb_test.html
@@ -40,7 +40,7 @@
             <tbody>
                 <tr>
                     <th colspan="1">Nil
-                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from incubation of PBMCs in culture media without antigens.">i</span></th>
+                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from incubation of PBMCs in culture media without antigens." data-tooltip-position="tooltip-right">i</span></th>
                     <td colspan="1">&le; 10 spots</td>
                 </tr>
                 <tr>
@@ -51,7 +51,7 @@
                 </tr>
                 <tr>
                     <th colspan="1">Mitogen
-                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from stimulation of PBMCs with mitogen without adjustment for the number of spots resulting from incubation of PBMCs without antigens.">i</span>
+                        <span class="info-icon" data-tooltip="NOTE: The number of spots resulting from stimulation of PBMCs with mitogen without adjustment for the number of spots resulting from incubation of PBMCs without antigens."data-tooltip-position="tooltip-right">i</span>
                     </th>
                     <td colspan="1">Any</td>
                 </tr>


### PR DESCRIPTION
Introduces interactive info-icon tooltips across multiple TB-related subchapter pages to provide contextual notes and clarifications for table entries. Updates table structures and footnotes for improved clarity, adds frequency columns, and revises regimen and dosage details.

NB: This only affects table 1 to 9