### PR TITLE
Update District TB coordinators contacts

### DIFF
--- a/pages/15_appendix_district_tb_coordinators_(by_district).html
+++ b/pages/15_appendix_district_tb_coordinators_(by_district).html
@@ -19,18 +19,18 @@
           <div>
             <img alt="aut" src="../assets/ic_title_icon.svg" width="50" height="50" class="ic_title_icon">
           </div>
-          
+
           <p>XV. Appendix: District TB Coordinators (by district)</p>
         </div>
         <div>
-          <p class="uk-heading-divider"><i>Last Updated October 2025</i></p>
+          <p class="uk-heading-divider"><i>Last Updated March 2026</i></p>
         </div>
         <table class="uk-table uk-table-small uk-table-divider">
           <thead>
             <tr>
               <th scope="col">DISTRICT</th>
               <th scope="col">COUNTIES</th>
-              <th scope="col">TB COORDINATOR</th>
+              <th scope="col">TB COORDINATOR/MEDICAL CONSULTANT</th>
             </tr>
           </thead>
           <tbody>
@@ -60,7 +60,7 @@
                 <br /><br />
                 Back-Up for TB Coordinator:<br />
                 <b>Cheryl Bandy</b><br />
-                Nursing & Clinical Director<br />
+                Nursing &amp; Clinical Director<br />
                 <b>Phone: </b>706-295-6704 ext 115<br />
                 <a href="mailto:Cheryl.Bandy@dph.ga.gov"
                   >Cheryl.Bandy@dph.ga.gov</a
@@ -72,12 +72,15 @@
                 District TB Coordinator<br />
                 Northwest Georgia Health District <br />
                 1309 Redmond Road, NW <br />
-                Rome, Georgia 30165 <br /><br />
+                Rome, Georgia 30165 <br />
                 <b>Phone:</b> (706) 802-5311 ext 127 <br />
                 <b>Fax:</b> (706) 295-6150<br />
                 <a href="mailto:Stacy.Henderson@dph.ga.gov"
                   >Stacy.Henderson@dph.ga.gov</a
-                >
+                ><br /><br />
+                <b>Dr. Gary Voccio</b> – Med Consultant<br />
+                1309 Redmond Rd NW, Rome, GA 30165<br />
+                <b>Phone:</b> 706-295-6704 ext 137
               </td>
             </tr>
             <tr>
@@ -116,7 +119,10 @@
                 <b>Cell:</b> (770) 842-5713<br />
                 <a href="mailto:Tammy.Bowling@dph.ga.gov"
                   >Tammy.Bowling@dph.ga.gov</a
-                >
+                ><br /><br />
+                <b>Dr. Mark Elam</b> – Med Consultant<br />
+                208 Woodland Ave, Chattanooga, TN 37405<br />
+                <b>Phone:</b> 706-483-4999
               </td>
             </tr>
             <tr>
@@ -139,19 +145,27 @@
                 District TB Coordinator<br />
                 District 2 Public Health <br />
                 1280 Athens St. <br />
-                Gainesville, GA30507 <br />
+                Gainesville, GA 30507 <br />
                 <b>Phone: </b>(770) 718-5084<br />
                 <b>Cell: </b>(678) 780-6176<br />
-                <b>Fax: </b>(770)535-5958<br />
+                <b>Fax: </b>(770) 535-5958<br />
                 <a href="mailto:melindadolphyn@dph.ga.gov"
                   >melindadolphyn@dph.ga.gov</a
-                >
+                ><br /><br />
+                <b>Dr. Thomas Murray</b> – Med Consultant<br />
+                1280 Athens St, Gainesville, GA 30507<br />
+                <b>Phone:</b> 770-519-2532
               </td>
             </tr>
             <tr>
               <td>
                 <b>DISTRICT 3 UNIT 1</b><br />COBB<br /><br />
                 Back-Up for TB Coordinator:<br />
+                <b>Sherri S. Gary, MSN, R.N.</b><br />
+                <b>Phone: </b>(770) 514-2366<br />
+                <a href="mailto:Sherri.gary@dph.ga.gov"
+                  >Sherri.gary@dph.ga.gov</a
+                >
               </td>
               <td>
                 Cobb<br />Douglas<br /><br />
@@ -171,7 +185,10 @@
                 <b>Fax: </b>(770) 514-2801<br />
                 <a href="mailto:Phyllistine.Gardner@dph.ga.gov"
                   >Phyllistine.Gardner@dph.ga.gov</a
-                >
+                ><br /><br />
+                <b>Dr. Aliya Yamin</b> – Med Consultant<br />
+                1650 County Services Pkwy, Marietta, GA 30008<br />
+                <b>Phone:</b> 770-514-2343
               </td>
             </tr>
             <tr>
@@ -179,21 +196,12 @@
                 <b>DISTRICT 3 UNIT 2</b> <br />FULTON<br /><br />
                 Director of Clinical Operations and Health Services<br />
                 Office: (404) 612-0923<br />
-                <b>Cell: </b>(770) 876-4591<br />
-                <br /><br /><b>Hassan Zadeh, M.H.A.</b><br />
-                Director of Clinic Operations Tuberculosis & Oral Health<br />
-                Medical and Preventive Services<br />
-                Fulton County Board of Health<br />
-                <b>Phone: </b>(770) 520-7507<br />
-                <b>Cell: </b>(770) 876-8444<br />
-                <a href="mailto:hassan.zadeh@dph.ga.gov"
-                  >hassan.zadeh@dph.ga.gov</a
-                ><br /><br />
+                <b>Cell: </b>(770) 876-4591<br /><br />
               </td>
               <td>
                 Fulton<br /><br />
-                <b>TB Clinic:</b> 770-520-7500 Option “1”<br />
-                for Clinical Services then Option “3” for TB<br /><br />
+                <b>TB Clinic:</b> 770-520-7500 Option "1"<br />
+                for Clinical Services then Option "3" for TB<br /><br />
                 Back-Up for TB Coordinator:<br />
                 <b>Keyanna Fluellen-White B.S.</b><br />
                 <b>Phone: </b>(770) 520-7522<br />
@@ -212,6 +220,12 @@
                 <b>Fax: </b>(770) 264-7532 <br />
                 <a href="mailto:Omar.Mohamed1@dph.ga.gov"
                   >Omar.Mohamed1@dph.ga.gov</a
+                ><br /><br />
+                <b>Karen Davis</b> – NP-C MSN MPH<br />
+                10 Park Place SE, Atlanta, GA 30303<br />
+                <b>Phone:</b> 770-520-7519<br />
+                <a href="mailto:Karen.davis13@dph.ga.gov"
+                  >Karen.davis13@dph.ga.gov</a
                 >
               </td>
             </tr>
@@ -222,6 +236,11 @@
                 <b>Clayton Co. Health Dept.</b><br />
                 678—610-7199<br /><br />
                 Back-Up for TB Coordinator:<br />
+                <b>Brienna Sylvester</b><br />
+                <b>Phone: </b>678-610-7199<br />
+                <a href="mailto:Brienna.sylvester@dph.ga.gov"
+                  >Brienna.sylvester@dph.ga.gov</a
+                >
               </td>
               <td>
                 <b>Interim TB Coordinator</b><br />
@@ -231,23 +250,25 @@
                 Clayton County Board of Health<br />
                 1117 Battlecreek Road<br />
                 Jonesboro, GA 30236<br />
-                <b>Phone: </b>(678) 610-7487<br />
+                <b>Phone: </b>(678) 610-7199 ext. 7487<br />
                 <b>Fax: </b>(770) 603-4874<br />
-                <a href="mailto:Rodney.Wilson@dph.ga.gov">Rodney.Wilson@dph.ga.gov</a>
+                <a href="mailto:Rodney.Wilson@dph.ga.gov">Rodney.Wilson@dph.ga.gov</a><br /><br />
+                <b>Dr. R. Prokesch &amp; Dr. L. Diamond</b> – Med Consultants<br />
+                1365 Rock Quarry Rd. Ste 302<br />
+                Stockbridge, GA 30281<br />
+                <b>Phone:</b> 770-991-1500
               </td>
             </tr>
             <tr>
               <td>
                 <b>DISTRICT 3 UNIT 4</b> <br />GWINNETT<br /><br />
                 Back-Up for TB Coordinator:<br />
-                <b>Dorian Freeman, MPH MSN NP</b><br />
-                Clinical Infectious Disease Program Director<br />
+                <b>Hoa Le, CMA</b><br />
                 GNR Public Health<br />
-                <b>Phone: </b>(678) 660-7009<br />
-                <b>Cell: </b>(470) 604-2914<br />
+                <b>Phone: </b>678-442-6880 ext 436<br />
                 <b>Fax: </b>1-866-399-7601<br />
-                <a href="mailto:Dorian.Freeman@gnrhealth.com"
-                  >Dorian.Freeman@gnrhealth.com</a
+                <a href="mailto:Hoa.le@gnrhealth.com"
+                  >Hoa.le@gnrhealth.com</a
                 >
               </td>
               <td>
@@ -268,40 +289,35 @@
                 <b>Phone: </b>770-785-4345
               </td>
               <td>
-                <b>Interim TB Coordinator</b><br />
-                <b>Hoa Le, CMA</b><br />
-                <b>Clinical Operations Manager</b><br />
+                <b>TB Coordinator</b><br />
+                <b>Wesley Westbrooke, MBA, BSBA</b><br />
+                <b>TB Program Manager</b><br />
                 GNR Public Health<br />
-                455 Grayson Highway Suite 400<br />
+                455 Grayson Highway, Suite 400<br />
                 Lawrenceville, GA 30046<br />
-                <b>Phone: </b>(678) 442-6880 ext.436 <br />
+                <b>Phone: </b>(678) 442-6880 ext.417<br />
+                <b>Cell: </b>678-231-0701<br />
                 <b>Fax: </b>1-866-399-7601<br />
-                <a href="mailto:Hoa.Le@gnrhealth.com"
-                  >Hoa.Le@gnrhealth.com</a
+                <a href="mailto:wesley.westbrooke@gnrhealth.com"
+                  >wesley.westbrooke@gnrhealth.com</a
+                ><br /><br />
+                <b>Dr. Nidhip Patel</b> – Med Consultant<br />
+                Northside Hospital<br />
+                <b>Phone:</b> 678-312-4076<br />
+                <a href="mailto:Nidhip.patel@northside.com"
+                  >Nidhip.patel@northside.com</a
                 >
-                <br><br/>
-                <b>April Garcia, BA</b><br />
-                <b>Hoa Le, CMA</b><br />
-                <b>Communicable Disease Specialist</b><br />
-                <b>Phone: </b> (678) 442-6880 x 434  <br />
-                <b>Fax: </b>(770) 237-5317<br />
-                <a href="mailto:April.Garcia@gnrhealth.com"
-                  >April.Garcia@gnrhealth.com</a
-                >
-
               </td>
             </tr>
             <tr>
               <td>
                 <b>DISTRICT 3 UNIT 5</b> <br />DEKALB<br /><br />
-                
 
-                <b>Sendss contact:</b><br /><br />
-                <b>Madina Huka, MPH</b><br />
-                Business Support Analyst 1 <br />
-                <b>Phone: </b> (404) 297-7144 <br />
-                <a href="mailto:Madina.Huka1@dph.ga.gov"
-                  >Madina.Huka1@dph.ga.gov</a
+                <b>Data Specialist:</b><br /><br />
+                <b>Sandra Harris, MPH, BA</b><br />
+                <b>Phone: </b>(404) 297-7144<br />
+                <a href="mailto:Sandra.harris@dph.ga.gov"
+                  >Sandra.harris@dph.ga.gov</a
                 >
               </td>
               <td>
@@ -311,16 +327,14 @@
                 <b>Phone: </b>(404) 508-7885<br />
                 <b>Fax: </b>(404) 508-7844<br /><br />
                 Back-Up for TB Coordinator:<br />
-                <b>Rebecca Ajibola, BSN, MPH</b><br />
-                CDS Specialist Supervisor<br />
-                <b>Phone: </b>(404) 508-7955<br />
-                <b>Mobile: </b>(470) 457-2887<br />
-                <a href="mailto:Rebecca.Ajibola@dph.ga.gov"
-                  >Rebecca.Ajibola@dph.ga.gov</a
+                <b>Jerry Leh Hickman, RN</b><br />
+                <b>Phone: </b>(404) 508-7857<br />
+                <a href="mailto:jerryleh.hickman@dph.ga.gov"
+                  >jerryleh.hickman@dph.ga.gov</a
                 >
               </td>
               <td>
-                <b>Lucas O’Reilly, MPH</b><br />
+                <b>Lucas O'Reilly, MPH</b><br />
                 <b><i>TB and Refugee Program Coordinator</i></b
                 ><br />
                 Infectious Diseases and Refugee Health / DeKalb Public Health
@@ -336,24 +350,39 @@
                   >Mailing Address for All DeKalb Public Health Locations:
                   <br />
                   PO Box 987 / Decatur, GA 30031-0987<br />
-                </small>
+                </small><br />
+                <b>Dr. Oladele Alawode</b> – Med Consultant<br />
+                445 Winn Way, Decatur, GA 30030<br />
+                <b>Phone:</b> 404-294-3800<br /><br />
+                <b>Dr. Jane Scott</b><br />
+                <b>Cell:</b> 706-231-2251<br />
+                <a href="mailto:jane.scott@dph.ga.gov"
+                  >jane.scott@dph.ga.gov</a
+                >
               </td>
             </tr>
             <tr>
               <td>
                 <b>DISTRICT 4</b> <br />LAGRANGE<br /><br />
                 Assistant to TB Coordinator:<br /><br />
-                <b>Tina Arnold</b><br />
-                Healthcare Program Consultant<br />
+                <b>Raven Smith</b><br />
+                Business Support Analyst 1,<br />
+                Pharmacy &amp; TB Program<br />
+                Administrative Assistant, Adult Health<br />
+                District 4, Georgia Department of Public Health<br />
+                301 Main Street/LaGrange, Ga. 30240<br />
                 <b>Phone: </b>(706) 298-7761<br />
-                <a href="mailto:Tina.Arnold@dph.ga.gov"
-                  >Tina.Arnold@dph.ga.gov</a
-                >
+                <b>Cell: </b>(706) 881-4448<br />
+                <b>Fax: </b>(706) 845-4350<br />
+                <a href="mailto:Raven.Smith1@dph.ga.gov"
+                  >Raven.Smith1@dph.ga.gov</a
+                ><br />
+                District4Health.org
               </td>
               <td>
                 Butts<br />Carroll<br />Coweta<br />Fayette<br />Heard<br />Henry<br />Lamar<br />Meriwether<br />Pike<br />Spalding<br />Troup<br />Upson<br /><br />
                 Back-Up for TB Coordinator:<br />
-                <b>Amy L. McColley RN CBE-MC</b><br />
+                <b>Amy L. McColley, RN, CBE-MC</b><br />
                 Clinical Services Coordinator<br />
                 <b>Office Phone: </b>706-298-7749<br />
                 <b>Work Cell: </b>706-594-6641<br />
@@ -362,17 +391,21 @@
                 >
               </td>
               <td>
-                <b>Melody Wegienka, RN</b><br />
+                <b>Lauren Denney, RN, BSN</b><br />
                 District TB Coordinator<br />
                 District Four Public Health Services<br />
                 301 Main Street<br />
                 LaGrange, Georgia 30241<br />
-                <b>Phone:</b> (706) 298-7764<br />
                 <b>Cell:</b> (706) 616-2749<br />
                 <b>Fax:</b> (706) 845-4294<br />
-                <a href="mailto:Melody.Wegienka@dph.ga.gov"
-                  >Melody.Wegienka@dph.ga.gov</a
-                >
+                <a href="mailto:lauren.denney@dph.ga.gov"
+                  >lauren.denney@dph.ga.gov</a
+                ><br /><br />
+                <b>Dr. Laura Larson</b> – Med Consultant<br />
+                100 Professional Pl Ste 310<br />
+                Carrollton, GA 30117<br />
+                <b>Phone:</b> 770-812-5837<br />
+                <b>Cell:</b> 770-235-0239
               </td>
             </tr>
             <tr>
@@ -390,7 +423,7 @@
                 >
               </td>
               <td>
-                <b>Stacey Upshaw RN MSN</b><br />
+                <b>Stacey Upshaw, RN, MSN</b><br />
                 Assistant Nursing Director<br />
                 South Central Health District<br />
                 105 E. Jackson St.<br />
@@ -401,44 +434,47 @@
                 <b>Fax: </b>(478) 275-6575<br />
                 <a href="mailto:Stacey.Upshaw@dph.ga.gov"
                   >Stacey.Upshaw@dph.ga.gov</a
-                >
+                ><br /><br />
+                <b>Dr. Thomas Cradt</b> – Med Consultant<br />
+                <b>Phone:</b> 478-275-6545
               </td>
             </tr>
             <tr>
               <td>
                 <b>DISTRICT 5 UNIT 2</b> <br />MACON<br /><br />
                 TB Back-up:<br />
-                <b>Amber Erickson, DrPH, MPH</b><br />
-                <b>Director of Epidemiology,</b><br />
-                Assessment and Research Initiatives<br />
-                <b>Cell: </b>478-972-6067<br />
-                <b>Fax: </b>478-751-6072<br />
-                <a href="mailto:amber.erickson@dph.ga.gov"
-                  >amber.erickson@dph.ga.gov</a
+                <b>Judy McChargue, RN</b><br />
+                District Nursing Director<br />
+                <b>Cell: </b>478-951-9740<br />
+                <a href="mailto:Judy.mcchargue@dph.ga.gov"
+                  >Judy.mcchargue@dph.ga.gov</a
                 >
               </td>
               <td>
                 Baldwin<br />Bibb<br />Crawford<br />Hancock<br />Houston<br />Jasper<br />Jones<br />Monroe<br />Peach<br />Putnam<br />Twiggs<br />Washington<br />Wilkinson
               </td>
               <td>
-                <b>Ashley O’Neal, BSN, RNC-MNN, CLC</b><br />
+                <b>Caitlin V. Martin, BSN, RN</b><br />
                 District TB Coordinator<br />
                 North Central Health District<br />
                 201 2nd Street Suite 1100 <br />
                 Macon, Ga, 31201 <br />
                 <b>Phone:</b> 478-342-0317<br />
                 <b>Fax:</b> (478) 752-1710<br />
-                <a href="mailto:Ashley.Oneal@dph.ga.gov"
-                  >Ashley.Oneal@dph.ga.gov</a
-                >
+                <a href="mailto:Caitlin.Martin@dph.ga.gov"
+                  >Caitlin.Martin@dph.ga.gov</a
+                ><br /><br />
+                <b>Dr. Don Nelson</b> – Med Consultant<br />
+                202 Fairfield Ct, Dublin, GA 31021<br />
+                <b>Phone:</b> 478-697-2110
               </td>
             </tr>
             <tr>
               <td>
                 <b>DISTRICT 6</b> <br />AUGUSTA<br /><br />
                 Back-Up for TB Coordinator:<br />
-                Vacant <br><br/>
-                Administrative Assistant :<br />
+                Vacant <br /><br />
+                Administrative Assistant:<br />
                 Sandra Heard<br />
                 <b>Phone: </b>706-721-5901
               </td>
@@ -446,18 +482,25 @@
                 Burke<br />Columbia<br />Emanuel<br />Glascock<br />Jefferson<br />Jenkins<br />Lincoln<br />McDuffie<br />Richmond<br />Screven<br />Taliaferro<br />Warren<br />Wilkes<br /><br />
                 <b>Georgia State Prisons</b><br />
                 (contact info at end of listing) <br /><br />
-
-              
-              </td>
-              <td>
-                <b><i>Interim TB Coordinator</i></b> 
-                <br />
+                Back-Up for TB Coordinator:<br />
                 <b>Louise LaRosa, RN</b><br />
-                950 Laney Walker Blvd. Augusta, GA 30901 <br />
+                950 Laney Walker Blvd.<br />
+                Augusta, Ga 30901<br />
                 <b>Phone: </b>(706) 721-5946<br />
                 <a href="mailto:Louise.LaRosa@dph.ga.gov"
                   >Louise.LaRosa@dph.ga.gov</a
                 >
+              </td>
+              <td>
+                <b>Virginia Russell, RN, BSN</b><br />
+                950 Laney Walker Blvd.<br />
+                Augusta, Ga 30901<br />
+                <b>Phone: </b>(706) 721-5846<br />
+                <a href="mailto:virginia.russell1@dph.ga.gov"
+                  >virginia.russell1@dph.ga.gov</a
+                ><br /><br />
+                <b>Dr. William Davis</b> – Med Consultant<br />
+                <b>Phone:</b> 706-631-4121
               </td>
             </tr>
             <tr>
@@ -493,22 +536,27 @@
                 >
               </td>
               <td>
-                <b>Summer Walker, RN, BSN</b><br />
+                <b>Tracy Epps, RN</b><br />
                 District TB Coordinator<br />
                 West Central Health District<br />
                 5601 Veterans Parkway<br />
                 Columbus, Georgia 31904<br />
-                <b>Phone:</b> (706) 321-6244<br />
-                <b>Cell Phone:</b> (706) 366-4649<br />
-                <b>Fax:</b> (706)-321-6384<br />
-                <b>Main:</b> (706) 321-6300<br /><br />
+                <b>Phone:</b> (706) 321-6411 EXT 6621<br />
+                <b>Cell Phone:</b> (706)<br />
+                <b>Fax:</b> (706) 321-6384<br />
+                <b>Main:</b> (706) 321-6300<br />
+                <a href="mailto:Tracy.Epps@dph.ga.gov"
+                  >Tracy.Epps@dph.ga.gov</a
+                ><br /><br />
                 <b>Infectious Disease Coordinator</b><br />
                 <b>Katina Anthony, RN, BSN</b><br />
                 <b>Office:</b> (706) 321-6420<br />
                 <b>Fax:</b> (706) 321-6428<br />
                 <a href="mailto:Katina.Anthony@dph.ga.gov"
                   >Katina.Anthony@dph.ga.gov</a
-                >
+                ><br /><br />
+                <b>Vacant</b> – Med Consultant<br />
+                <b>Phone:</b>
               </td>
             </tr>
             <tr>
@@ -516,26 +564,27 @@
               <td>
                 Ben Hill<br />Berrien<br />Brooks<br />Cook<br />Echols<br />Irwin<br />Lanier<br />Lowndes<br />Tift<br />Turner<br /><br />
                 Back-Up for TB Coordinator:<br />
-                <b>Stacey Porter LPN</b><br />
+                <b>Stacey Porter, LPN</b><br />
                 District TB Nurse<br />
-                <b>Phone: </b>(229) 245-8711 ext. 236<br />
+                <b>Phone: </b>(229) 245-8711 ext. 106<br />
                 <b>Fax: </b>(229) 245-8432<br />
                 <a href="mailto:Stacey.Porter@dph.ga.gov"
                   >Stacey.Porter@dph.ga.gov</a
                 >
               </td>
               <td>
-                <b>Teresa Hritz RN</b><br />
+                <b>Teresa Hritz, RN</b><br />
                 Infectious Disease/TB Coordinator<br />
                 South Health District<br />
                 2704 North Oak Street Building E<br />
                 P.O. Box 5147<br />
-                Valdosta Georgia 31603<br />
-                <b>Phone: </b>(229) 245-8711 ext. 239<br />
+                Valdosta, Georgia 31603<br />
+                <b>Phone: </b>(229) 245-8711 ext. 104<br />
                 <b>Fax: </b>(229) 245-8432<br />
                 <a href="mailto:Teresa.Hritz@dph.ga.gov"
                   >Teresa.Hritz@dph.ga.gov</a
-                >
+                ><br /><br />
+                Medical Consultant – Vacant
               </td>
             </tr>
             <tr>
@@ -544,9 +593,9 @@
                 Back-up for TB Coordinator:<br /><br />
                 <b>Chasity Taylor, MPH, BSN, RN</b><br />
                 Infectious Disease Program Director<br />
-                1710 S. Slappery Blvd.<br />
+                1710 S. Slappey Blvd.<br />
                 Albany, GA 31701<br />
-                <b>Phone: </b> 29-638-6424 x 6632<br />
+                <b>Phone: </b>229-638-6424 x 6632<br />
                 <b>Cell: </b>229-854-9412<br />
                 <a href="mailto:Chasity.Taylor1@dph.ga.gov"
                   >Chasity.Taylor1@dph.ga.gov</a
@@ -555,7 +604,7 @@
               <td>
                 Baker<br />Calhoun<br />Colquitt<br />Decatur<br />Dougherty<br />Early<br />Grady<br />Lee<br />Miller<br />Mitchell<br />Seminole<br />Terrell<br />Thomas<br />Worth<br /><br />
                 TB Specialist:<br />
-                <b>Laurie McGhin RN</b><br />
+                <b>Laurie McGhin, RN</b><br />
                 <b>Phone: </b>(229) 638-6426 ext.6633<br />
                 <a href="mailto:laurie.mcghin@dph.ga.gov"
                   >laurie.mcghin@dph.ga.gov</a
@@ -569,7 +618,10 @@
                 <b>Fax:</b> (229) 638-6427<br />
                 <a href="mailto:Courtney.Parker@dph.ga.gov"
                   >Courtney.Parker@dph.ga.gov</a
-                >
+                ><br /><br />
+                <b>Dr. Tamara Johnson</b> – Med Consultant<br />
+                3131 South Main St, Moultrie, GA 31768<br />
+                <b>Phone:</b> 870-395-0405
               </td>
             </tr>
             <tr>
@@ -577,25 +629,25 @@
               <td>
                 Bryan<br />Camden<br />Chatham<br />Effingham<br />Glynn<br />Liberty<br />Long<br />McIntosh<br /><br />
                 Back-Up for TB Coordinator:<br />
-                <b>Grace Greene, RN, BSN, MPH</b><br />
                 District TB Nurse<br />
-                <b>Phone: </b>912-262-3033<br />
-                <b>Fax: </b>912-262-2315<br />
-                <a href="mailto:Grace.Greene@dph.ga.gov"
-                  >Grace.Greene@dph.ga.gov</a
-                >
+                <b>Phone: </b><br />
+                <b>Mobile: </b><br />
+                <b>Fax: </b>
               </td>
               <td>
-                <b>Jennifer Reimann, RN</b> <br />
+                <b>Jennifer Riemann, RN</b> <br />
                 District TB Coordinator<br />
                 TB Program/Coastal Health District<br />
                 420 Mall Blvd. Savannah, GA 31406<br /><br />
                 <b>Phone:</b> 912-644-5224<br />
                 <b>Fax:</b> 912-349-2326<br />
-                <b>Mobile:</b>  912-332-0875<br />
+                <b>Mobile:</b> 912-332-0875<br />
                 <a href="mailto:Jennifer.Riemann@dph.ga.gov"
                   >Jennifer.Riemann@dph.ga.gov</a
-                >
+                ><br /><br />
+                <b>Dr. Maria Mascolo</b> – Med Consultant<br />
+                131 Silverwood Ct, Rincon, GA 31326<br />
+                <b>Phone:</b> 912-826-3927
               </td>
             </tr>
             <tr>
@@ -608,10 +660,10 @@
                 Appling<br />Atkinson<br />Bacon<br />Brantley<br />Bulloch<br />Candler<br />Charlton<br />Clinch<br />Coffee<br />Evans<br />Jeff
                 Davis<br />Pierce<br />Tattnall<br />Toombs<br />Ware<br />Wayne<br /><br />
                 Back-Up for TB Coordinator:<br />
-                <b>Shalander Howard BSN RN</b><br />
+                <b>Shalander Howard, BSN, RN</b><br />
                 Toombs County Health Department<br />
                 714 N.W. Broad Street<br />
-                Lyons Georgia 30474<br />
+                Lyons, Georgia 30474<br />
                 <b>Phone: </b>(912) 526-8109<br />
                 <b>Fax: </b>(912) 526-6504<br />
                 <a href="mailto:shalander.howard@dph.ga.gov"
@@ -627,10 +679,12 @@
                 Waycross GA 31501-5393<br />
                 <b>Phone: </b>(912) 283-1996<br />
                 <b>Fax: </b>(912) 283-0894<br />
-                <b>Cell: </b>912-590-2313<br />
+                <b>Cell: </b>912-282-8052<br />
                 <a href="mailto:Ashley.Tanner1@dph.ga.gov"
                   >Ashley.Tanner1@dph.ga.gov</a
-                >
+                ><br /><br />
+                <b>Dr. Gregory Felzien</b> – Med Consultant<br />
+                <b>Phone:</b> 404-510-2288
               </td>
             </tr>
             <tr>
@@ -638,8 +692,8 @@
               <td>
                 Barrow<br />Clarke<br />Elbert<br />Greene<br />Jackson<br />Madison<br />Morgan<br />Oconee<br />Oglethorpe<br />Walton<br /><br />
                 Back-Up for TB Coordinator:<br />
-                <b>Olivia Echols MSN MPH RN</b><br />
-                Infectious Disease Coordinator<br />
+                <b>Olivia Echols, MSN, MPH, RN</b><br />
+                <i>Infectious Disease Coordinator</i><br />
                 District Epidemiologist<br />
                 <b>Phone: </b>(706) 583-2772<br />
                 <b>Cell: </b>(706) 621-8877<br />
@@ -649,15 +703,14 @@
                 >
               </td>
               <td>
-                <b>Gavin Cloud, MPH</b><br />
+                <b>Jessica Liddell, MS</b><br />
                 TB Case Manager<br />
                 220 Research Drive<br />
                 Athens, GA 30605<br />
-                <b>Phone:</b> (706) 583-2791<br />
-                <b>Cell:</b> (706) 201-4565<br />
-                <b>Fax:</b> (706) 369-5640<br />
-                <a href="mailto:Gavin.Cloud1@dph.ga.gov"
-                  >Gavin.Cloud1@dph.ga.gov</a
+                <b>Phone:</b> (706) 583-2420<br />
+                <b>Cell:</b> 762-400-2039<br />
+                <a href="mailto:jessica.liddell@dph.ga.gov"
+                  >jessica.liddell@dph.ga.gov</a
                 >
               </td>
             </tr>
@@ -669,20 +722,20 @@
                 3001 Gordon Hwy.<br />
                 Grovetown GA 30813<br />
                 <b>Phone: </b>(706) 855-4948<br />
-                <a href="mailto:llarowe@wellpath.us">llarowe@wellpath.us</a>
+                <a href="mailto:llarowe@teamcenturion.com">llarowe@teamcenturion.com</a>
               </td>
               <td></td>
               <td>
-                <b>Millie Reeves PAC</b><br />
+                <b>Millie Reeves, PAC</b><br />
                 Statewide Tuberculosis Program Coordinator for Georgia
                 Department of Corrections<br />
                 Augusta State Medical Prison<br />
                 <b>Phone: </b>(706) 855-4823<br />
-                <b>Cell: </b>(706) 832-8343<br />
+                <b>Cell: </b>706-755-4604<br />
                 <b>Fax: </b>(706) 869-7938<br />
                 <a href="mailto:Millie.Reeves@gdc.ga.gov"
                   >Millie.Reeves@gdc.ga.gov</a
-                >
+                ><br />
                 <a href="mailto:Mreeves1@Teamcenturion.com"
                   >Mreeves1@Teamcenturion.com</a
                 >

--- a/pages/15_appendix_district_tb_coordinators_(by_district).html
+++ b/pages/15_appendix_district_tb_coordinators_(by_district).html
@@ -23,7 +23,7 @@
           <p>XV. Appendix: District TB Coordinators (by district)</p>
         </div>
         <div>
-          <p class="uk-heading-divider"><i>Last Updated March 2026</i></p>
+          <p class="uk-heading-divider"><i>Last Updated October 2025</i></p>
         </div>
         <table class="uk-table uk-table-small uk-table-divider">
           <thead>


### PR DESCRIPTION
Update contacts and formatting in appendix page (15_appendix_district_tb_coordinators_(by_district).html): set Last Updated to March 2026, rename column to "TB COORDINATOR/MEDICAL CONSULTANT", add and update numerous staff entries (names, titles, med consultants, phone numbers, emails, addresses), fix spacing/typos (&, commas, phone extensions), and correct several email addresses and mailing details. These are content and formatting updates to contact information only.