### PR TITLE
Fix contact info and DeKalb mailing format

### DIFF
--- a/pages/15_appendix_district_tb_coordinators_(by_district).html
+++ b/pages/15_appendix_district_tb_coordinators_(by_district).html
@@ -101,7 +101,7 @@
                 Back-Up for TB Coordinator:<br />
                 <b>Ashley Deverell, RN</b><br />
                 ID Program Manager<br />
-                <b>Phone:</b> (706) 529-5741 x11220<br />
+                <b>Phone:</b> (706) 529-5741 x1220<br />
                 <b>Fax:</b> (706) 529-5752<br />
                 <a href="mailto:Ashley.Deverell@dph.ga.gov"
                   >Ashley.Deverell@dph.ga.gov</a
@@ -253,7 +253,7 @@
                 <b>Phone: </b>(678) 610-7199 ext. 7487<br />
                 <b>Fax: </b>(770) 603-4874<br />
                 <a href="mailto:Rodney.Wilson@dph.ga.gov">Rodney.Wilson@dph.ga.gov</a><br /><br />
-                <b>Dr. R. Prokesch &amp; Dr. L. Diamond</b> – Med Consultants<br />
+                <b>Dr. R. Prokesch &amp; Dr. L. Diamond</b> <br />
                 1365 Rock Quarry Rd. Ste 302<br />
                 Stockbridge, GA 30281<br />
                 <b>Phone:</b> 770-991-1500
@@ -331,7 +331,13 @@
                 <b>Phone: </b>(404) 508-7857<br />
                 <a href="mailto:jerryleh.hickman@dph.ga.gov"
                   >jerryleh.hickman@dph.ga.gov</a
-                >
+                ><br />
+                <br />
+                <small
+                  >Mailing Address for All DeKalb Public Health Locations:
+                  <br />
+                  PO Box 987 / Decatur, GA 30031-0987<br />
+                </small>
               </td>
               <td>
                 <b>Lucas O'Reilly, MPH</b><br />
@@ -346,11 +352,7 @@
                 >
                 <br />
                 <br />
-                <small
-                  >Mailing Address for All DeKalb Public Health Locations:
-                  <br />
-                  PO Box 987 / Decatur, GA 30031-0987<br />
-                </small><br />
+                
                 <b>Dr. Oladele Alawode</b> – Med Consultant<br />
                 445 Winn Way, Decatur, GA 30030<br />
                 <b>Phone:</b> 404-294-3800<br /><br />


### PR DESCRIPTION
Correct Ashley Deverell's phone extension (x11220 -> x1220), remove the "– Med Consultants" suffix from Drs. Prokesch & Diamond, and consolidate/add the DeKalb mailing address under the DeKalb contact block (remove duplicate mailing block). Also tidy up a few line breaks/markup around the DeKalb email.